### PR TITLE
refactor(rustfmt): clean up and fix rustfmt configuration

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,5 +1,6 @@
-use argh::FromArgs;
 use std::path::PathBuf;
+
+use argh::FromArgs;
 
 #[derive(FromArgs)]
 /// Neverwinter Nights utility CLI.
@@ -85,19 +86,19 @@ pub(crate) struct PackCmd {
 }
 
 pub(crate) struct KeyPackCmd {
-    pub(crate) data_version: String,
+    pub(crate) data_version:     String,
     pub(crate) data_compression: String,
-    pub(crate) no_squash: bool,
-    pub(crate) no_symlinks: bool,
-    pub(crate) force: bool,
-    pub(crate) key: String,
-    pub(crate) source: PathBuf,
-    pub(crate) destination: PathBuf,
+    pub(crate) no_squash:        bool,
+    pub(crate) no_symlinks:      bool,
+    pub(crate) force:            bool,
+    pub(crate) key:              String,
+    pub(crate) source:           PathBuf,
+    pub(crate) destination:      PathBuf,
 }
 
 pub(crate) struct KeyUnpackCmd {
-    pub(crate) force: bool,
-    pub(crate) key: PathBuf,
+    pub(crate) force:       bool,
+    pub(crate) key:         PathBuf,
     pub(crate) destination: PathBuf,
 }
 

--- a/cli/src/inspect.rs
+++ b/cli/src/inspect.rs
@@ -1,14 +1,14 @@
-use crate::util::{Kind, detect_kind, write_stdout_line};
+use std::{fs::File, io::BufReader, path::Path};
+
 use nwn_erf::prelude::*;
 use nwn_gff::prelude::*;
 use nwn_key::prelude::*;
 use nwn_ssf::prelude::*;
 use nwn_tlk::prelude::*;
 use nwn_twoda::prelude::*;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
 use tracing::{debug, info, instrument};
+
+use crate::util::{Kind, detect_kind, write_stdout_line};
 
 #[instrument(level = "info", skip_all, err, fields(path = %path.display()))]
 pub(crate) fn run_inspect(path: &Path) -> Result<(), String> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-//! Command-line entrypoint for the NWN utility suite.
+#![doc = "Command-line entrypoint for the NWN utility suite."]
 
 mod args;
 mod inspect;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![doc = "Command-line entrypoint for the NWN utility suite."]
+//! Command-line entrypoint for the NWN utility suite.
 
 mod args;
 mod inspect;
@@ -10,8 +10,9 @@ mod pack;
 mod unpack;
 mod util;
 
-use args::{Cli, Command, NwsyncCommand};
 use std::process::ExitCode;
+
+use args::{Cli, Command, NwsyncCommand};
 use tracing::{error, instrument};
 
 fn main() -> ExitCode {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![doc = "Command-line entrypoint for the NWN utility suite."]
+//! Command-line entrypoint for the NWN utility suite.
 
 mod args;
 mod inspect;

--- a/cli/src/metadata.rs
+++ b/cli/src/metadata.rs
@@ -1,39 +1,43 @@
-use crate::util::{
-    RESOURCE_METADATA_FILENAME, ensure_output_file_ready, entry_is_dir, entry_is_file,
-    normalize_key_bif_filename, should_skip_top_level_dir, sorted_dir_entries,
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
 };
+
 use nwn_checksums::prelude::*;
 use nwn_erf::prelude::*;
 use nwn_key::prelude::*;
 use nwn_resman::prelude::*;
 use nwn_resref::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+
+use crate::util::{
+    RESOURCE_METADATA_FILENAME, ensure_output_file_ready, entry_is_dir, entry_is_file,
+    normalize_key_bif_filename, should_skip_top_level_dir, sorted_dir_entries,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ErfPackMetadata {
-    pub(crate) source: PathBuf,
-    pub(crate) source_md5: String,
-    pub(crate) file_type: String,
+    pub(crate) source:       PathBuf,
+    pub(crate) source_md5:   String,
+    pub(crate) file_type:    String,
     pub(crate) file_version: ErfVersion,
-    pub(crate) build_year: i32,
-    pub(crate) build_day: i32,
-    pub(crate) str_ref: i32,
-    pub(crate) loc_strings: BTreeMap<i32, String>,
-    pub(crate) oid: Option<String>,
-    pub(crate) entry_order: Vec<ResRef>,
-    pub(crate) file_md5s: BTreeMap<String, String>,
+    pub(crate) build_year:   i32,
+    pub(crate) build_day:    i32,
+    pub(crate) str_ref:      i32,
+    pub(crate) loc_strings:  BTreeMap<i32, String>,
+    pub(crate) oid:          Option<String>,
+    pub(crate) entry_order:  Vec<ResRef>,
+    pub(crate) file_md5s:    BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KeyPackMetadata {
-    pub(crate) source_key: PathBuf,
+    pub(crate) source_key:     PathBuf,
     pub(crate) source_key_md5: String,
-    pub(crate) bifs: Vec<String>,
-    pub(crate) bif_md5s: BTreeMap<String, String>,
-    pub(crate) file_md5s: BTreeMap<String, String>,
+    pub(crate) bifs:           Vec<String>,
+    pub(crate) bif_md5s:       BTreeMap<String, String>,
+    pub(crate) file_md5s:      BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,48 +67,48 @@ struct MetadataKindProbe {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ErfPackMetadataFile {
-    kind: MetadataKind,
-    source: PathBuf,
-    source_md5: String,
-    file_type: String,
+    kind:         MetadataKind,
+    source:       PathBuf,
+    source_md5:   String,
+    file_type:    String,
     file_version: ErfPackMetadataVersion,
-    build_year: i32,
-    build_day: i32,
-    str_ref: i32,
+    build_year:   i32,
+    build_day:    i32,
+    str_ref:      i32,
     #[serde(default)]
-    loc_strings: BTreeMap<i32, String>,
-    oid: Option<String>,
+    loc_strings:  BTreeMap<i32, String>,
+    oid:          Option<String>,
     #[serde(default)]
-    entry_order: Vec<String>,
+    entry_order:  Vec<String>,
     #[serde(default)]
-    file_md5s: BTreeMap<String, String>,
+    file_md5s:    BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct KeyPackMetadataFile {
-    kind: MetadataKind,
-    source_key: PathBuf,
+    kind:           MetadataKind,
+    source_key:     PathBuf,
     source_key_md5: String,
-    version: KeyPackMetadataVersion,
-    build_year: u32,
-    build_day: u32,
-    oid: Option<String>,
+    version:        KeyPackMetadataVersion,
+    build_year:     u32,
+    build_day:      u32,
+    oid:            Option<String>,
     #[serde(default)]
-    bifs: Vec<String>,
+    bifs:           Vec<String>,
     #[serde(default)]
-    bif_md5s: BTreeMap<String, String>,
+    bif_md5s:       BTreeMap<String, String>,
     #[serde(default)]
-    file_md5s: BTreeMap<String, String>,
+    file_md5s:      BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ResourceMetadataFile {
-    kind: MetadataKind,
-    source: PathBuf,
-    source_md5: String,
+    kind:        MetadataKind,
+    source:      PathBuf,
+    source_md5:  String,
     source_kind: String,
     #[serde(default)]
-    file_md5s: BTreeMap<String, String>,
+    file_md5s:   BTreeMap<String, String>,
 }
 
 impl From<ErfVersion> for ErfPackMetadataVersion {
@@ -137,16 +141,16 @@ impl From<KeyBifVersion> for KeyPackMetadataVersion {
 impl From<KeyPackMetadata> for KeyPackMetadataFile {
     fn from(value: KeyPackMetadata) -> Self {
         Self {
-            kind: MetadataKind::Key,
-            source_key: value.source_key,
+            kind:           MetadataKind::Key,
+            source_key:     value.source_key,
             source_key_md5: value.source_key_md5,
-            version: KeyPackMetadataVersion::V1,
-            build_year: 0,
-            build_day: 0,
-            oid: None,
-            bifs: value.bifs,
-            bif_md5s: value.bif_md5s,
-            file_md5s: value.file_md5s,
+            version:        KeyPackMetadataVersion::V1,
+            build_year:     0,
+            build_day:      0,
+            oid:            None,
+            bifs:           value.bifs,
+            bif_md5s:       value.bif_md5s,
+            file_md5s:      value.file_md5s,
         }
     }
 }
@@ -154,17 +158,17 @@ impl From<KeyPackMetadata> for KeyPackMetadataFile {
 impl ErfPackMetadata {
     fn from_file(value: ErfPackMetadataFile, metadata_path: &Path) -> Result<Self, String> {
         Ok(Self {
-            source: value.source,
-            source_md5: value.source_md5,
-            file_type: value.file_type,
+            source:       value.source,
+            source_md5:   value.source_md5,
+            file_type:    value.file_type,
             file_version: value.file_version.into(),
-            build_year: value.build_year,
-            build_day: value.build_day,
-            str_ref: value.str_ref,
-            loc_strings: value.loc_strings,
-            oid: value.oid,
-            entry_order: parse_entry_order(value.entry_order, metadata_path)?,
-            file_md5s: value.file_md5s,
+            build_year:   value.build_year,
+            build_day:    value.build_day,
+            str_ref:      value.str_ref,
+            loc_strings:  value.loc_strings,
+            oid:          value.oid,
+            entry_order:  parse_entry_order(value.entry_order, metadata_path)?,
+            file_md5s:    value.file_md5s,
         })
     }
 }
@@ -172,11 +176,11 @@ impl ErfPackMetadata {
 impl KeyPackMetadata {
     fn from_file(value: KeyPackMetadataFile) -> Self {
         Self {
-            source_key: value.source_key,
+            source_key:     value.source_key,
             source_key_md5: value.source_key_md5,
-            bifs: value.bifs,
-            bif_md5s: value.bif_md5s,
-            file_md5s: value.file_md5s,
+            bifs:           value.bifs,
+            bif_md5s:       value.bif_md5s,
+            file_md5s:      value.file_md5s,
         }
     }
 }
@@ -190,22 +194,22 @@ pub(crate) fn write_erf_pack_metadata(
     let metadata_path = destination.join(RESOURCE_METADATA_FILENAME);
     ensure_output_file_ready(&metadata_path, force)?;
     let value = ErfPackMetadataFile {
-        kind: MetadataKind::Erf,
-        source: input.to_path_buf(),
-        source_md5: md5_digest(
+        kind:         MetadataKind::Erf,
+        source:       input.to_path_buf(),
+        source_md5:   md5_digest(
             fs::read(input)
                 .map_err(|error| format!("failed to read {}: {error}", input.display()))?,
         )
         .to_string(),
-        file_type: erf.file_type.clone(),
+        file_type:    erf.file_type.clone(),
         file_version: erf.file_version.into(),
-        build_year: erf.build_year,
-        build_day: erf.build_day,
-        str_ref: erf.str_ref,
-        loc_strings: erf.loc_strings().clone(),
-        oid: erf.oid().map(str::to_string),
-        entry_order: serialize_entry_order(&erf.contents()),
-        file_md5s: snapshot_packable_files(destination)?,
+        build_year:   erf.build_year,
+        build_day:    erf.build_day,
+        str_ref:      erf.str_ref,
+        loc_strings:  erf.loc_strings().clone(),
+        oid:          erf.oid().map(str::to_string),
+        entry_order:  serialize_entry_order(&erf.contents()),
+        file_md5s:    snapshot_packable_files(destination)?,
     };
     fs::write(
         &metadata_path,
@@ -270,15 +274,15 @@ pub(crate) fn write_resource_metadata(
     let metadata_path = destination.join(RESOURCE_METADATA_FILENAME);
     ensure_output_file_ready(&metadata_path, force)?;
     let value = ResourceMetadataFile {
-        kind: MetadataKind::Resource,
-        source: input.to_path_buf(),
-        source_md5: md5_digest(
+        kind:        MetadataKind::Resource,
+        source:      input.to_path_buf(),
+        source_md5:  md5_digest(
             fs::read(input)
                 .map_err(|error| format!("failed to read {}: {error}", input.display()))?,
         )
         .to_string(),
         source_kind: source_kind.to_string(),
-        file_md5s: snapshot_packable_files(destination)?,
+        file_md5s:   snapshot_packable_files(destination)?,
     };
     fs::write(
         &metadata_path,
@@ -500,40 +504,41 @@ fn is_pack_metadata_file(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use nwn_restype::ResType;
+
+    use super::*;
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
 
     #[test]
     fn erf_metadata_file_round_trips_with_derived_dto() -> TestResult {
         let metadata = ErfPackMetadata {
-            source: PathBuf::from("example.erf"),
-            source_md5: "abc123".to_string(),
-            file_type: "ERF ".to_string(),
+            source:       PathBuf::from("example.erf"),
+            source_md5:   "abc123".to_string(),
+            file_type:    "ERF ".to_string(),
             file_version: ErfVersion::V1,
-            build_year: 2025,
-            build_day: 92,
-            str_ref: 7,
-            loc_strings: BTreeMap::from([(0, "Hello".to_string())]),
-            oid: Some("0123456789abcdef01234567".to_string()),
-            entry_order: vec![new_resolved_res_ref_from_filename("alpha.uti")?.into()],
-            file_md5s: BTreeMap::from([("alpha.uti".to_string(), "deadbeef".to_string())]),
+            build_year:   2025,
+            build_day:    92,
+            str_ref:      7,
+            loc_strings:  BTreeMap::from([(0, "Hello".to_string())]),
+            oid:          Some("0123456789abcdef01234567".to_string()),
+            entry_order:  vec![new_resolved_res_ref_from_filename("alpha.uti")?.into()],
+            file_md5s:    BTreeMap::from([("alpha.uti".to_string(), "deadbeef".to_string())]),
         };
 
         let file = ErfPackMetadataFile {
-            kind: MetadataKind::Erf,
-            source: metadata.source.clone(),
-            source_md5: metadata.source_md5.clone(),
-            file_type: metadata.file_type.clone(),
+            kind:         MetadataKind::Erf,
+            source:       metadata.source.clone(),
+            source_md5:   metadata.source_md5.clone(),
+            file_type:    metadata.file_type.clone(),
             file_version: metadata.file_version.into(),
-            build_year: metadata.build_year,
-            build_day: metadata.build_day,
-            str_ref: metadata.str_ref,
-            loc_strings: metadata.loc_strings.clone(),
-            oid: metadata.oid.clone(),
-            entry_order: serialize_entry_order(&metadata.entry_order),
-            file_md5s: metadata.file_md5s.clone(),
+            build_year:   metadata.build_year,
+            build_day:    metadata.build_day,
+            str_ref:      metadata.str_ref,
+            loc_strings:  metadata.loc_strings.clone(),
+            oid:          metadata.oid.clone(),
+            entry_order:  serialize_entry_order(&metadata.entry_order),
+            file_md5s:    metadata.file_md5s.clone(),
         };
 
         let json = serde_json::to_string(&file)?;
@@ -549,11 +554,11 @@ mod tests {
     #[test]
     fn key_metadata_file_round_trips_with_derived_dto() -> TestResult {
         let metadata = KeyPackMetadata {
-            source_key: PathBuf::from("test.key"),
+            source_key:     PathBuf::from("test.key"),
             source_key_md5: "abc123".to_string(),
-            bifs: vec!["data/test.bif".to_string()],
-            bif_md5s: BTreeMap::from([("data/test.bif".to_string(), "bifhash".to_string())]),
-            file_md5s: BTreeMap::from([("alpha.uti".to_string(), "reshash".to_string())]),
+            bifs:           vec!["data/test.bif".to_string()],
+            bif_md5s:       BTreeMap::from([("data/test.bif".to_string(), "bifhash".to_string())]),
+            file_md5s:      BTreeMap::from([("alpha.uti".to_string(), "reshash".to_string())]),
         };
 
         let json = serde_json::to_string(&KeyPackMetadataFile::from(metadata.clone()))?;

--- a/cli/src/nwsync.rs
+++ b/cli/src/nwsync.rs
@@ -1,16 +1,18 @@
-use crate::args::NwsyncFetchCmd;
-use crate::args::NwsyncPrintCmd;
-use crate::args::NwsyncPruneCmd;
-use crate::args::NwsyncWriteCmd;
-use crate::util::write_stdout_line;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
 use nwn_nwsync::prelude::*;
 use nwn_resman::prelude::*;
 use nwn_resnwsync::prelude::*;
 use nwn_resref::prelude::*;
-use std::fs;
-use std::path::Path;
-use std::path::PathBuf;
 use tracing::{debug, info, instrument};
+
+use crate::{
+    args::{NwsyncFetchCmd, NwsyncPrintCmd, NwsyncPruneCmd, NwsyncWriteCmd},
+    util::write_stdout_line,
+};
 
 #[instrument(
     level = "info",

--- a/cli/src/pack.rs
+++ b/cli/src/pack.rs
@@ -1,14 +1,11 @@
-use crate::args::{KeyPackCmd, PackCmd};
-use crate::metadata::{
-    ErfPackMetadata, copy_original_key_set, read_erf_pack_metadata, read_key_pack_metadata,
-    should_copy_original_erf, should_copy_original_key,
+use std::{
+    collections::HashSet,
+    ffi::OsStr,
+    fs::{self, File},
+    io::{self, BufReader, Cursor},
+    path::{Path, PathBuf},
 };
-use crate::util::{
-    Kind, RESOURCE_METADATA_FILENAME, collect_key_bif_entries, current_build_date, detect_kind,
-    ensure_output_file_ready, ensure_target_dir_ready, entry_is_dir, entry_is_file,
-    exo_compression_from_algorithm, infer_erf_type, is_gff_extension, parse_algorithm,
-    parse_erf_version, parse_key_version, should_skip_top_level_dir, sorted_dir_entries,
-};
+
 use nwn_checksums::prelude::*;
 use nwn_erf::prelude::*;
 use nwn_gff::prelude::*;
@@ -16,12 +13,21 @@ use nwn_gffjson::prelude::*;
 use nwn_key::prelude::*;
 use nwn_resref::prelude::*;
 use nwn_twoda::prelude::*;
-use std::collections::HashSet;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{self, BufReader, Cursor};
-use std::path::{Path, PathBuf};
 use tracing::{debug, info, instrument, warn};
+
+use crate::{
+    args::{KeyPackCmd, PackCmd},
+    metadata::{
+        ErfPackMetadata, copy_original_key_set, read_erf_pack_metadata, read_key_pack_metadata,
+        should_copy_original_erf, should_copy_original_key,
+    },
+    util::{
+        Kind, RESOURCE_METADATA_FILENAME, collect_key_bif_entries, current_build_date, detect_kind,
+        ensure_output_file_ready, ensure_target_dir_ready, entry_is_dir, entry_is_file,
+        exo_compression_from_algorithm, infer_erf_type, is_gff_extension, parse_algorithm,
+        parse_erf_version, parse_key_version, should_skip_top_level_dir, sorted_dir_entries,
+    },
+};
 
 #[instrument(
     level = "info",
@@ -352,7 +358,7 @@ pub(crate) enum PackSourceKind {
 
 #[derive(Clone)]
 pub(crate) struct PackSourceEntry {
-    pub(crate) rr: ResRef,
+    pub(crate) rr:     ResRef,
     pub(crate) source: PackSourceKind,
 }
 
@@ -487,7 +493,7 @@ fn pack_source_for_file(path: &Path) -> Result<PackSourceEntry, String> {
             ));
         }
         return Ok(PackSourceEntry {
-            rr: resolved.into(),
+            rr:     resolved.into(),
             source: PackSourceKind::GffJson(path.to_path_buf()),
         });
     }
@@ -495,7 +501,7 @@ fn pack_source_for_file(path: &Path) -> Result<PackSourceEntry, String> {
     let resolved = new_resolved_res_ref_from_filename(file_name)
         .map_err(|error| format!("{} is not a valid resref source: {error}", path.display()))?;
     Ok(PackSourceEntry {
-        rr: resolved.into(),
+        rr:     resolved.into(),
         source: PackSourceKind::File(path.to_path_buf()),
     })
 }

--- a/cli/src/unpack.rs
+++ b/cli/src/unpack.rs
@@ -1,11 +1,10 @@
-use crate::args::{KeyUnpackCmd, UnpackCmd};
-use crate::metadata::write_erf_pack_metadata;
-use crate::metadata::write_key_pack_metadata;
-use crate::metadata::write_resource_metadata;
-use crate::util::{
-    Kind, detect_kind, ensure_output_file_ready, ensure_target_dir_ready, is_gff_extension,
-    unpacked_raw_target, write_lines,
+use std::{
+    ffi::OsStr,
+    fs::{self, File},
+    io::{BufReader, Cursor},
+    path::Path,
 };
+
 use nwn_erf::prelude::*;
 use nwn_gff::prelude::*;
 use nwn_gffjson::prelude::*;
@@ -13,11 +12,16 @@ use nwn_key::prelude::*;
 use nwn_resman::prelude::*;
 use nwn_resref::prelude::*;
 use nwn_twoda::prelude::*;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{BufReader, Cursor};
-use std::path::Path;
 use tracing::{debug, info, instrument, warn};
+
+use crate::{
+    args::{KeyUnpackCmd, UnpackCmd},
+    metadata::{write_erf_pack_metadata, write_key_pack_metadata, write_resource_metadata},
+    util::{
+        Kind, detect_kind, ensure_output_file_ready, ensure_target_dir_ready, is_gff_extension,
+        unpacked_raw_target, write_lines,
+    },
+};
 
 #[instrument(
     level = "info",
@@ -42,8 +46,8 @@ pub(crate) fn run_unpack(cmd: UnpackCmd) -> Result<(), String> {
     match detect_kind(&cmd.input) {
         Some(Kind::Erf) => unpack_erf_to_dir(&cmd.input, &cmd.directory, cmd.force),
         Some(Kind::Key) => run_key_unpack(KeyUnpackCmd {
-            force: cmd.force,
-            key: cmd.input,
+            force:       cmd.force,
+            key:         cmd.input,
             destination: cmd.directory,
         }),
         Some(Kind::Gff) => unpack_gff_to_json(&cmd.input, &cmd.directory, cmd.force),

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -1,14 +1,17 @@
+use std::{
+    ffi::OsStr,
+    fs::{self, File},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
 use nwn_compressedbuf::prelude::*;
 use nwn_erf::prelude::*;
 use nwn_exo::prelude::*;
 use nwn_game::prelude::*;
 use nwn_key::prelude::*;
 use nwn_resref::prelude::*;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) const RESOURCE_METADATA_FILENAME: &str = "resource.json";
 
@@ -24,7 +27,7 @@ pub(crate) enum Kind {
 
 pub(crate) struct DirEntryInfo {
     pub(crate) file_name: String,
-    pub(crate) path: PathBuf,
+    pub(crate) path:      PathBuf,
 }
 
 pub(crate) fn detect_kind(path: &Path) -> Option<Kind> {

--- a/crates/checksums/src/digest.rs
+++ b/crates/checksums/src/digest.rs
@@ -1,6 +1,7 @@
-use crate::{Md5Digest, ParseSecureHashError, SECURE_HASH_HEX_LEN, SecureHash};
 use sha1::{Digest as _, Sha1};
 use tracing::instrument;
+
+use crate::{Md5Digest, ParseSecureHashError, SECURE_HASH_HEX_LEN, SecureHash};
 
 /// Computes the SHA-1 digest for `data`.
 #[instrument(level = "debug", skip_all)]

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -1,10 +1,10 @@
 #![forbid(unsafe_code)]
 //! Digest helpers used throughout the workspace.
 //!
-//! This crate provides small typed wrappers around SHA-1 and MD5 digests together with
-//! conversion helpers. SHA-1 is used heavily by NWSync manifests, KEY/BIF metadata, and
-//! archive payload tracking, while MD5 is used by the CLI metadata files that support
-//! round-tripping unpacked content.
+//! This crate provides small typed wrappers around SHA-1 and MD5 digests
+//! together with conversion helpers. SHA-1 is used heavily by NWSync manifests,
+//! KEY/BIF metadata, and archive payload tracking, while MD5 is used by the CLI
+//! metadata files that support round-tripping unpacked content.
 //!
 //! Start with [`secure_hash`], [`parse_secure_hash`], and [`md5_digest`].
 

--- a/crates/checksums/src/types.rs
+++ b/crates/checksums/src/types.rs
@@ -1,6 +1,4 @@
-use std::error::Error;
-use std::fmt;
-use std::str::FromStr;
+use std::{error::Error, fmt, str::FromStr};
 
 /// The lowercase hexadecimal length of a SHA-1 digest.
 pub const SECURE_HASH_HEX_LEN: usize = 40;

--- a/crates/compressedbuf/src/io.rs
+++ b/crates/compressedbuf/src/io.rs
@@ -1,12 +1,13 @@
-use crate::{Algorithm, CompressedBufResult, VERSION, ZLIB_VERSION, ZSTD_VERSION};
-use flate2::Compression;
-use flate2::read::ZlibDecoder;
-use flate2::write::ZlibEncoder;
-use nwn_util::{ExpectationError, expect, read_bytes_or_err};
 use std::io::{self, Cursor, Read, Write};
+
+use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
+use nwn_util::{ExpectationError, expect, read_bytes_or_err};
 use tracing::{debug, instrument};
 
-/// Encodes a four-byte ASCII magic string into the packed integer form used by the format.
+use crate::{Algorithm, CompressedBufResult, VERSION, ZLIB_VERSION, ZSTD_VERSION};
+
+/// Encodes a four-byte ASCII magic string into the packed integer form used by
+/// the format.
 pub fn make_magic(magic: &str) -> Result<u32, ExpectationError> {
     expect(magic.len() == 4, "magic needs to be 4 bytes exactly")?;
     let bytes: [u8; 4] = magic
@@ -94,7 +95,8 @@ pub fn compress_bytes(
     Ok(output)
 }
 
-/// Reads all bytes from `reader`, compresses them, and writes the encoded buffer.
+/// Reads all bytes from `reader`, compresses them, and writes the encoded
+/// buffer.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?algorithm, magic))]
 pub fn compress_reader<R: Read, W: Write>(
     writer: &mut W,

--- a/crates/compressedbuf/src/lib.rs
+++ b/crates/compressedbuf/src/lib.rs
@@ -1,12 +1,13 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for the EXO compressed-buffer wrapper.
 //!
-//! Several NWN formats store payloads behind a small framing format that records a magic
-//! value, the compression algorithm, and the expected uncompressed size. This crate knows
-//! how to decode and encode that wrapper for both in-memory buffers and generic streams.
+//! Several NWN formats store payloads behind a small framing format that
+//! records a magic value, the compression algorithm, and the expected
+//! uncompressed size. This crate knows how to decode and encode that wrapper
+//! for both in-memory buffers and generic streams.
 //!
-//! The main entry points are [`decompress_bytes`], [`decompress_reader`], [`compress_bytes`],
-//! and [`compress_writer`].
+//! The main entry points are [`decompress_bytes`], [`decompress_reader`],
+//! [`compress_bytes`], and [`compress_writer`].
 mod io;
 mod types;
 

--- a/crates/compressedbuf/src/types.rs
+++ b/crates/compressedbuf/src/types.rs
@@ -1,6 +1,6 @@
+use std::{fmt, io};
+
 use nwn_util::ExpectationError;
-use std::fmt;
-use std::io;
 
 pub(crate) const VERSION: u32 = 3;
 pub(crate) const ZLIB_VERSION: u32 = 1;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,12 +1,12 @@
 #![forbid(unsafe_code)]
 //! Core NWN vocabulary shared across format crates.
 //!
-//! This crate intentionally stays small. It defines the language ids, gender selector, and
-//! dialog string reference type that appear across TLK, GFF, SSF, and higher-level resource
-//! loading code.
+//! This crate intentionally stays small. It defines the language ids, gender
+//! selector, and dialog string reference type that appear across TLK, GFF, SSF,
+//! and higher-level resource loading code.
 //!
-//! Use [`Language`] and [`resolve_language`] when you need to translate between textual and
-//! numeric language identifiers.
+//! Use [`Language`] and [`resolve_language`] when you need to translate between
+//! textual and numeric language identifiers.
 
 mod resolve;
 mod types;

--- a/crates/core/src/resolve.rs
+++ b/crates/core/src/resolve.rs
@@ -1,5 +1,6 @@
-use crate::{Language, ParseLanguageError};
 use tracing::instrument;
+
+use crate::{Language, ParseLanguageError};
 
 /// Resolves a language from a numeric id, short code, or English name.
 #[instrument(level = "debug", skip_all, err, fields(input = %input))]

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1,6 +1,4 @@
-use std::error::Error;
-use std::fmt;
-use std::str::FromStr;
+use std::{error::Error, fmt, str::FromStr};
 
 /// A TLK string reference.
 pub type StrRef = u32;
@@ -37,14 +35,14 @@ pub enum Gender {
 /// An error returned when a language identifier cannot be parsed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseLanguageError {
-    pub(crate) input: String,
+    pub(crate) input:  String,
     pub(crate) reason: String,
 }
 
 impl ParseLanguageError {
     pub(crate) fn new(input: &str, reason: impl Into<String>) -> Self {
         Self {
-            input: input.to_string(),
+            input:  input.to_string(),
             reason: reason.into(),
         }
     }

--- a/crates/erf/src/io.rs
+++ b/crates/erf/src/io.rs
@@ -1,21 +1,25 @@
-use crate::{Erf, ErfError, ErfResMeta, ErfResult, ErfVersion, HEADER_SIZE, VALID_ERF_TYPES};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::Path,
+    time::SystemTime,
+};
+
 use nwn_checksums::{EMPTY_SECURE_HASH, SecureHash};
 use nwn_compressedbuf::{Algorithm, compress_writer as compress_buf_writer};
 use nwn_exo::{EXO_RES_FILE_COMPRESSED_BUF_MAGIC, ExoResFileCompressionType};
 use nwn_resman::{Res, SharedReadSeek, new_res_origin, shared_stream};
 use nwn_resref::{ResRef, new_res_ref};
 use nwn_util::{from_nwn_encoding, read_bytes_or_err, to_nwn_encoding};
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::Path;
-use std::time::SystemTime;
 use tracing::{debug, instrument};
+
+use crate::{Erf, ErfError, ErfResMeta, ErfResult, ErfVersion, HEADER_SIZE, VALID_ERF_TYPES};
 
 /// Reads an ERF-family archive from a seekable reader.
 ///
-/// The returned [`Erf`] contains lazily readable [`nwn_resman::Res`] entries backed by the
-/// supplied stream.
+/// The returned [`Erf`] contains lazily readable [`nwn_resman::Res`] entries
+/// backed by the supplied stream.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_erf<R>(reader: R, filename: impl Into<String>) -> ErfResult<Erf>
 where
@@ -34,7 +38,8 @@ pub fn read_erf_from_file(path: impl AsRef<Path>) -> ErfResult<Erf> {
 
 /// Reads an ERF-family archive from a shared stream handle.
 ///
-/// This is the most direct constructor when the caller already manages stream sharing.
+/// This is the most direct constructor when the caller already manages stream
+/// sharing.
 #[instrument(level = "debug", skip_all, err, fields(path = %filename))]
 pub fn read_erf_shared(stream: SharedReadSeek, filename: String) -> ErfResult<Erf> {
     let mut io = stream
@@ -248,8 +253,9 @@ fn resource_table_offset_looks_valid<R: Read + Seek + ?Sized>(
 #[allow(clippy::too_many_arguments)]
 /// Writes an ERF-family archive.
 ///
-/// `entries` defines the archive order. For each entry, `entry_writer` must write the raw
-/// payload bytes and return the uncompressed byte length together with the payload SHA-1.
+/// `entries` defines the archive order. For each entry, `entry_writer` must
+/// write the raw payload bytes and return the uncompressed byte length together
+/// with the payload SHA-1.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/erf/src/lib.rs
+++ b/crates/erf/src/lib.rs
@@ -1,12 +1,13 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for ERF-family archives.
 //!
-//! NWN uses the same broad archive structure for `ERF`, `MOD`, `HAK`, and `NWM` files. This
-//! crate parses those containers into an [`Erf`] that also implements
-//! [`nwn_resman::ResContainer`], so archive entries can participate directly in layered
-//! resource resolution.
+//! NWN uses the same broad archive structure for `ERF`, `MOD`, `HAK`, and `NWM`
+//! files. This crate parses those containers into an [`Erf`] that also
+//! implements [`nwn_resman::ResContainer`], so archive entries can participate
+//! directly in layered resource resolution.
 //!
-//! Start with [`read_erf`], [`read_erf_from_file`], [`read_erf_shared`], and [`write_erf`].
+//! Start with [`read_erf`], [`read_erf_from_file`], [`read_erf_shared`], and
+//! [`write_erf`].
 
 mod io;
 mod types;

--- a/crates/erf/src/types.rs
+++ b/crates/erf/src/types.rs
@@ -1,12 +1,10 @@
+use std::{collections::BTreeMap, fmt, io, time::SystemTime};
+
 use indexmap::IndexMap;
 use nwn_compressedbuf::CompressedBufError;
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult};
 use nwn_resref::{ResRef, ResRefError};
 use nwn_util::{EncodingConversionError, ExpectationError};
-use std::collections::BTreeMap;
-use std::fmt;
-use std::io;
-use std::time::SystemTime;
 
 pub(crate) const HEADER_SIZE: u64 = 160;
 pub(crate) const VALID_ERF_TYPES: [&str; 4] = ["NWM ", "MOD ", "ERF ", "HAK "];
@@ -16,7 +14,8 @@ pub(crate) const VALID_ERF_TYPES: [&str; 4] = ["NWM ", "MOD ", "ERF ", "HAK "];
 pub enum ErfError {
     /// An underlying IO operation failed.
     Io(io::Error),
-    /// Resource manager setup failed while constructing archive-backed [`Res`] entries.
+    /// Resource manager setup failed while constructing archive-backed [`Res`]
+    /// entries.
     ResMan(ResManError),
     /// A resource reference inside the archive was invalid.
     ResRef(ResRefError),
@@ -96,7 +95,8 @@ pub type ErfResult<T> = Result<T, ErfError>;
 pub enum ErfVersion {
     /// Legacy archive layout without per-entry compression metadata.
     V1,
-    /// Enhanced-edition layout with optional per-entry compression and an archive OID.
+    /// Enhanced-edition layout with optional per-entry compression and an
+    /// archive OID.
     E1,
 }
 
@@ -107,21 +107,22 @@ pub enum ErfVersion {
 /// [`nwn_resman::ResContainer`] for use with [`nwn_resman::ResMan`].
 pub struct Erf {
     /// The archive modification time when known.
-    pub mtime: SystemTime,
-    /// The four-byte archive type tag such as `ERF `, `MOD `, `HAK `, or `NWM `.
-    pub file_type: String,
+    pub mtime:              SystemTime,
+    /// The four-byte archive type tag such as `ERF `, `MOD `, `HAK `, or `NWM
+    /// `.
+    pub file_type:          String,
     /// The archive version.
-    pub file_version: ErfVersion,
-    pub(crate) filename: String,
+    pub file_version:       ErfVersion,
+    pub(crate) filename:    String,
     /// Build year stored in the archive header.
-    pub build_year: i32,
+    pub build_year:         i32,
     /// Build day stored in the archive header.
-    pub build_day: i32,
+    pub build_day:          i32,
     /// Localized string reference stored in the archive header.
-    pub str_ref: i32,
+    pub str_ref:            i32,
     pub(crate) loc_strings: BTreeMap<i32, String>,
-    pub(crate) entries: IndexMap<ResRef, Res>,
-    pub(crate) oid: Option<String>,
+    pub(crate) entries:     IndexMap<ResRef, Res>,
+    pub(crate) oid:         Option<String>,
 }
 
 impl Erf {
@@ -175,8 +176,8 @@ impl ResContainer for Erf {
 
 #[derive(Debug)]
 pub(crate) struct ErfResMeta {
-    pub offset: u64,
-    pub disk_size: usize,
+    pub offset:            u64,
+    pub disk_size:         usize,
     pub uncompressed_size: usize,
-    pub compression: nwn_exo::ExoResFileCompressionType,
+    pub compression:       nwn_exo::ExoResFileCompressionType,
 }

--- a/crates/exo/src/lib.rs
+++ b/crates/exo/src/lib.rs
@@ -1,8 +1,9 @@
 #![forbid(unsafe_code)]
 //! Shared EXO-level constants and enums.
 //!
-//! This crate is intentionally narrow. It contains the compression markers and magic values
-//! that appear in EXO-backed container formats such as ERF, KEY/BIF, and compressed buffers.
+//! This crate is intentionally narrow. It contains the compression markers and
+//! magic values that appear in EXO-backed container formats such as ERF,
+//! KEY/BIF, and compressed buffers.
 
 mod constants;
 mod types;

--- a/crates/exo/src/types.rs
+++ b/crates/exo/src/types.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+
 use tracing::{debug, instrument};
 
 /// Compression markers stored by EXO resource containers.

--- a/crates/game/src/builder.rs
+++ b/crates/game/src/builder.rs
@@ -1,18 +1,24 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use nwn_resman::ResMan;
+use nwn_resnwsync::{ManifestSha1, new_resnwsync_manifest, open_nwsync};
+use tracing::{debug, info, instrument};
+
 use crate::{
     DEFAULT_KEYFILES, GameError, GameResult, expand_tilde, load_key, read_erf_from_file,
     read_resdir,
 };
-use nwn_resman::ResMan;
-use nwn_resnwsync::{ManifestSha1, new_resnwsync_manifest, open_nwsync};
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tracing::{debug, info, instrument};
 
 #[allow(clippy::too_many_arguments)]
-/// Builds a conventional layered [`nwn_resman::ResMan`] for an NWN installation.
+/// Builds a conventional layered [`nwn_resman::ResMan`] for an NWN
+/// installation.
 ///
-/// The resulting manager may include, in precedence order, additional directories, override
-/// directories, NWSync manifests, additional ERFs, and the selected KEY/BIF sets.
+/// The resulting manager may include, in precedence order, additional
+/// directories, override directories, NWSync manifests, additional ERFs, and
+/// the selected KEY/BIF sets.
 #[instrument(
     level = "info",
     skip(

--- a/crates/game/src/discovery.rs
+++ b/crates/game/src/discovery.rs
@@ -1,8 +1,12 @@
-use crate::{GameError, GameResult, Platform};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
 use serde::Deserialize;
-use std::fs;
-use std::path::{Path, PathBuf};
 use tracing::{debug, info, instrument, warn};
+
+use crate::{GameError, GameResult, Platform};
 
 #[derive(Debug, Deserialize)]
 struct BeamdogSettings {
@@ -11,8 +15,8 @@ struct BeamdogSettings {
 
 /// Locates the NWN user directory.
 ///
-/// Resolution order is: explicit override, `NWN_HOME`, `NWN_USER_DIRECTORY`, then the
-/// platform-specific default location.
+/// Resolution order is: explicit override, `NWN_HOME`, `NWN_USER_DIRECTORY`,
+/// then the platform-specific default location.
 #[instrument(level = "info", skip_all, err, fields(override_dir))]
 pub fn find_user_root(override_dir: &str) -> GameResult<PathBuf> {
     find_user_root_impl(
@@ -25,8 +29,8 @@ pub fn find_user_root(override_dir: &str) -> GameResult<PathBuf> {
 
 /// Locates the NWN installation root.
 ///
-/// Resolution order is: explicit override, `NWN_ROOT`, Steam install heuristics, then Beamdog
-/// client settings heuristics.
+/// Resolution order is: explicit override, `NWN_ROOT`, Steam install
+/// heuristics, then Beamdog client settings heuristics.
 #[instrument(level = "info", skip_all, err, fields(override_dir))]
 pub fn find_nwn_root(override_dir: &str) -> GameResult<PathBuf> {
     find_nwn_root_impl(
@@ -77,7 +81,8 @@ where
             Ok(path)
         }
         _ => Err(GameError::msg(
-            "Could not locate NWN user directory; try --userdirectory or set NWN_HOME (NWN_USER_DIRECTORY also works, but is considered alternate)",
+            "Could not locate NWN user directory; try --userdirectory or set NWN_HOME \
+             (NWN_USER_DIRECTORY also works, but is considered alternate)",
         )),
     }
 }

--- a/crates/game/src/keyload.rs
+++ b/crates/game/src/keyload.rs
@@ -1,10 +1,14 @@
-use crate::{GameResult, normalize_relative_path, read_key_table, shared_stream};
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use nwn_key::BifResolver;
 use nwn_resman::ResMan;
-use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use tracing::{info, instrument, warn};
+
+use crate::{GameResult, normalize_relative_path, read_key_table, shared_stream};
 
 #[instrument(
     level = "info",

--- a/crates/game/src/lib.rs
+++ b/crates/game/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! High-level helpers for working against a real NWN installation.
 //!
-//! This crate sits above the low-level container and format crates. It knows how to locate
-//! the game root and user directory, choose the conventional KEY load order, include override
-//! directories and NWSync manifests, and return a ready-to-query [`ResMan`](nwn_resman::ResMan).
+//! This crate sits above the low-level container and format crates. It knows
+//! how to locate the game root and user directory, choose the conventional KEY
+//! load order, include override directories and NWSync manifests, and return a
+//! ready-to-query [`ResMan`](nwn_resman::ResMan).
 //!
 //! The primary entry points are [`find_nwn_root`], [`find_user_root`], and
 //! [`new_default_resman`].

--- a/crates/game/src/types.rs
+++ b/crates/game/src/types.rs
@@ -1,9 +1,9 @@
+use std::{fmt, io};
+
 use nwn_erf::ErfError;
 use nwn_key::KeyError;
 use nwn_resdir::ResDirError;
 use nwn_resnwsync::ResNWSyncError;
-use std::fmt;
-use std::io;
 
 /// GFF-family extensions commonly treated as generic GFF payloads by the CLI.
 pub const GFF_EXTENSIONS: &[&str] = &[

--- a/crates/gff/src/io.rs
+++ b/crates/gff/src/io.rs
@@ -1,62 +1,64 @@
+use std::io::{self, Read, Seek, SeekFrom, Write};
+
+use nwn_util::{expect, from_nwn_encoding, read_bytes_or_err, read_str_or_err, to_nwn_encoding};
+use tracing::{debug, instrument};
+
 use crate::{
     GffCExoLocString, GffError, GffField, GffFieldKind, GffResult, GffRoot, GffStruct, GffValue,
     HEADER_SIZE, ensure_label,
 };
-use nwn_util::{expect, from_nwn_encoding, read_bytes_or_err, read_str_or_err, to_nwn_encoding};
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use tracing::{debug, instrument};
 
 #[derive(Debug, Clone)]
 struct Header {
-    struct_offset: u32,
-    struct_count: u32,
-    field_offset: u32,
-    field_count: u32,
-    label_offset: u32,
-    label_count: u32,
-    field_data_offset: u32,
-    field_data_size: u32,
+    struct_offset:        u32,
+    struct_count:         u32,
+    field_offset:         u32,
+    field_count:          u32,
+    label_offset:         u32,
+    label_count:          u32,
+    field_data_offset:    u32,
+    field_data_size:      u32,
     field_indices_offset: u32,
-    field_indices_size: u32,
-    list_indices_offset: u32,
-    list_indices_size: u32,
+    field_indices_size:   u32,
+    list_indices_offset:  u32,
+    list_indices_size:    u32,
 }
 
 #[derive(Debug, Clone)]
 struct RawStructEntry {
-    id: i32,
+    id:             i32,
     data_or_offset: i32,
-    field_count: i32,
+    field_count:    i32,
 }
 
 #[derive(Debug, Clone)]
 struct RawFieldEntry {
-    field_kind: GffFieldKind,
-    label_index: i32,
+    field_kind:     GffFieldKind,
+    label_index:    i32,
     data_or_offset: i32,
 }
 
 #[derive(Debug, Default)]
 struct WriteState {
-    labels: Vec<String>,
-    structs: Vec<WriteStructEntry>,
-    fields: Vec<WriteFieldEntry>,
-    field_data: Vec<u8>,
+    labels:        Vec<String>,
+    structs:       Vec<WriteStructEntry>,
+    fields:        Vec<WriteFieldEntry>,
+    field_data:    Vec<u8>,
     field_indices: Vec<i32>,
-    list_indices: Vec<i32>,
+    list_indices:  Vec<i32>,
 }
 
 #[derive(Debug, Clone, Default)]
 struct WriteStructEntry {
-    id: i32,
+    id:             i32,
     data_or_offset: i32,
-    field_count: i32,
+    field_count:    i32,
 }
 
 #[derive(Debug, Clone)]
 struct WriteFieldEntry {
-    field_kind: GffFieldKind,
-    label_index: i32,
+    field_kind:     GffFieldKind,
+    label_index:    i32,
     data_or_offset: i32,
 }
 
@@ -74,18 +76,18 @@ pub fn read_gff_root<R: Read + Seek>(reader: &mut R) -> GffResult<GffRoot> {
     )?;
 
     let mut header = Header {
-        struct_offset: read_u32(reader)?,
-        struct_count: read_u32(reader)?,
-        field_offset: read_u32(reader)?,
-        field_count: read_u32(reader)?,
-        label_offset: read_u32(reader)?,
-        label_count: read_u32(reader)?,
-        field_data_offset: read_u32(reader)?,
-        field_data_size: read_u32(reader)?,
+        struct_offset:        read_u32(reader)?,
+        struct_count:         read_u32(reader)?,
+        field_offset:         read_u32(reader)?,
+        field_count:          read_u32(reader)?,
+        label_offset:         read_u32(reader)?,
+        label_count:          read_u32(reader)?,
+        field_data_offset:    read_u32(reader)?,
+        field_data_size:      read_u32(reader)?,
         field_indices_offset: read_u32(reader)?,
-        field_indices_size: read_u32(reader)?,
-        list_indices_offset: read_u32(reader)?,
-        list_indices_size: read_u32(reader)?,
+        field_indices_size:   read_u32(reader)?,
+        list_indices_offset:  read_u32(reader)?,
+        list_indices_size:    read_u32(reader)?,
     };
 
     normalize_index_offsets(reader, start, &mut header)?;
@@ -451,7 +453,10 @@ fn parse_field<R: Read + Seek>(
                         .map_err(|_error| GffError::msg("negative CExoLocString payload size"))?,
                 "invalid CExoLocString payload size",
             )?;
-            GffValue::CExoLocString(GffCExoLocString { str_ref, entries })
+            GffValue::CExoLocString(GffCExoLocString {
+                str_ref,
+                entries,
+            })
         }
         GffFieldKind::Void => {
             seek_field_data(reader, start, header, raw.data_or_offset)?;
@@ -706,9 +711,9 @@ fn read_struct_entries<R: Read + Seek>(
     (0..header.struct_count)
         .map(|_| {
             Ok(RawStructEntry {
-                id: read_i32(reader)?,
+                id:             read_i32(reader)?,
                 data_or_offset: read_i32(reader)?,
-                field_count: read_i32(reader)?,
+                field_count:    read_i32(reader)?,
             })
         })
         .collect()

--- a/crates/gff/src/lib.rs
+++ b/crates/gff/src/lib.rs
@@ -1,12 +1,14 @@
 #![forbid(unsafe_code)]
 //! Typed reader and writer for `GFF V3.2`.
 //!
-//! Generic File Format documents back a large share of NWN gameplay data. This crate models
-//! a document as a [`GffRoot`] containing nested [`GffStruct`] values and typed [`GffValue`]
-//! fields while preserving field order for round-tripping.
+//! Generic File Format documents back a large share of NWN gameplay data. This
+//! crate models a document as a [`GffRoot`] containing nested [`GffStruct`]
+//! values and typed [`GffValue`] fields while preserving field order for
+//! round-tripping.
 //!
-//! Use [`read_gff_root`] and [`write_gff_root`] for binary IO, and construct new documents
-//! with [`GffRoot::new`] or the convenience helpers re-exported from this crate.
+//! Use [`read_gff_root`] and [`write_gff_root`] for binary IO, and construct
+//! new documents with [`GffRoot::new`] or the convenience helpers re-exported
+//! from this crate.
 
 mod io;
 mod types;

--- a/crates/gff/src/types.rs
+++ b/crates/gff/src/types.rs
@@ -1,7 +1,7 @@
+use std::{fmt, io};
+
 use nwn_core::{BAD_STRREF, StrRef};
 use nwn_util::ExpectationError;
-use std::fmt;
-use std::io;
 
 type GffByte = u8;
 type GffChar = i8;
@@ -22,9 +22,9 @@ pub(crate) const HEADER_SIZE: usize = 56;
 
 /// A `CExoLocString` value.
 #[derive(Debug, Clone, PartialEq)]
-///
-/// A localized string may either reference a TLK entry via [`str_ref`](Self::str_ref) or carry
-/// inline language-specific overrides in [`entries`](Self::entries).
+/// A localized string may either reference a TLK entry via
+/// [`str_ref`](Self::str_ref) or carry inline language-specific overrides in
+/// [`entries`](Self::entries).
 pub struct GffCExoLocString {
     /// The fallback TLK string reference.
     pub str_ref: StrRef,
@@ -44,8 +44,8 @@ impl Default for GffCExoLocString {
 /// The primitive and compound value kinds supported by GFF.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
-///
-/// These correspond directly to the numeric field type ids stored in the binary format.
+/// These correspond directly to the numeric field type ids stored in the binary
+/// format.
 pub enum GffFieldKind {
     /// An unsigned 8-bit integer.
     Byte = 0,
@@ -123,7 +123,6 @@ impl GffFieldKind {
 
 /// A typed GFF field value.
 #[derive(Debug, Clone, PartialEq)]
-///
 /// The enum variants mirror the canonical `GFF V3.2` field kinds.
 pub enum GffValue {
     /// An unsigned 8-bit integer.
@@ -186,8 +185,8 @@ impl GffValue {
 
 /// A labeled GFF field.
 #[derive(Debug, Clone, PartialEq)]
-///
-/// Labels are stored on the containing [`GffStruct`]; this type only wraps the typed value.
+/// Labels are stored on the containing [`GffStruct`]; this type only wraps the
+/// typed value.
 pub struct GffField {
     value: GffValue,
 }
@@ -195,7 +194,9 @@ pub struct GffField {
 impl GffField {
     /// Creates a field from a typed value.
     pub fn new(value: GffValue) -> Self {
-        Self { value }
+        Self {
+            value,
+        }
     }
 
     /// Returns the kind of the stored value.
@@ -211,7 +212,6 @@ impl GffField {
 
 /// A GFF structure containing labeled fields.
 #[derive(Debug, Clone, PartialEq)]
-///
 /// Fields preserve insertion order and labels are unique within a structure.
 pub struct GffStruct {
     /// The structure id stored in the document.
@@ -268,24 +268,23 @@ impl GffStruct {
 
 /// A complete GFF document.
 #[derive(Debug, Clone, PartialEq)]
-///
 /// NWN conventionally stores the root structure with id `-1`.
 pub struct GffRoot {
     /// The four-byte document type tag.
-    pub file_type: String,
+    pub file_type:    String,
     /// The four-byte document version tag.
     pub file_version: String,
     /// The root structure.
-    pub root: GffStruct,
+    pub root:         GffStruct,
 }
 
 impl GffRoot {
     /// Creates a new root document with version `V3.2`.
     pub fn new(file_type: impl Into<String>) -> Self {
         Self {
-            file_type: file_type.into(),
+            file_type:    file_type.into(),
             file_version: "V3.2".to_string(),
-            root: GffStruct::new(-1),
+            root:         GffStruct::new(-1),
         }
     }
 

--- a/crates/gffjson/src/decode.rs
+++ b/crates/gffjson/src/decode.rs
@@ -1,4 +1,3 @@
-use crate::{GffJsonError, GffJsonResult};
 use nwn_core::BAD_STRREF;
 use nwn_gff::{
     GffCExoLocString, GffRoot, GffStruct, GffValue, new_c_exo_loc_string, new_gff_root,
@@ -7,6 +6,8 @@ use nwn_gff::{
 use nwn_util::expect;
 use serde_json::{Map, Value};
 use tracing::instrument;
+
+use crate::{GffJsonError, GffJsonResult};
 
 /// Populates a GFF struct from its JSON representation.
 #[instrument(level = "debug", skip_all, err)]

--- a/crates/gffjson/src/encode.rs
+++ b/crates/gffjson/src/encode.rs
@@ -1,8 +1,9 @@
-use crate::{BASE64_ALPHABET, GffJsonError, GffJsonResult};
 use nwn_core::BAD_STRREF;
 use nwn_gff::{GffRoot, GffStruct, GffValue};
 use serde_json::{Map, Number, Value};
 use tracing::instrument;
+
+use crate::{BASE64_ALPHABET, GffJsonError, GffJsonResult};
 
 /// Converts a GFF struct to the JSON representation used by this crate.
 #[instrument(level = "debug", skip_all, err)]

--- a/crates/gffjson/src/lib.rs
+++ b/crates/gffjson/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! JSON bridge for the [`nwn_gff`] data model.
 //!
-//! This crate defines a stable JSON representation for [`nwn_gff::GffRoot`] documents. It is
-//! primarily used by the CLI unpack/pack workflow so that GFF-family resources can be edited
-//! as human-readable JSON and rebuilt without losing type information.
+//! This crate defines a stable JSON representation for [`nwn_gff::GffRoot`]
+//! documents. It is primarily used by the CLI unpack/pack workflow so that
+//! GFF-family resources can be edited as human-readable JSON and rebuilt
+//! without losing type information.
 //!
 //! Start with [`gff_root_to_json_value`], [`gff_root_to_pretty_json_string`],
 //! [`gff_root_from_json_value`], and [`gff_root_from_json_str`].

--- a/crates/gffjson/src/types.rs
+++ b/crates/gffjson/src/types.rs
@@ -1,7 +1,7 @@
+use std::{error::Error, fmt};
+
 use nwn_gff::GffError;
 use nwn_util::ExpectationError;
-use std::error::Error;
-use std::fmt;
 
 pub(crate) const BASE64_ALPHABET: &[u8; 64] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/crates/key/src/io.rs
+++ b/crates/key/src/io.rs
@@ -1,23 +1,27 @@
-use crate::{
-    BifHandle, BifResolver, HEADER_SIZE, KeyBifEntry, KeyBifVersion, KeyEntry, KeyError, KeyResult,
-    KeyTable, LoadedBif, VariableResource, WriteBifResult,
+use std::{
+    fs::{self, File},
+    io::{self, BufWriter, Read, Seek, SeekFrom, Write},
+    path::Path,
+    sync::Mutex,
 };
+
 use nwn_checksums::{EMPTY_SECURE_HASH, SecureHash};
 use nwn_compressedbuf::Algorithm;
 use nwn_exo::{EXO_RES_FILE_COMPRESSED_BUF_MAGIC, ExoResFileCompressionType};
 use nwn_resman::shared_stream;
 use nwn_resref::{ResRef, new_res_ref};
 use nwn_restype::ResType;
-use std::fs::{self, File};
-use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
-use std::path::Path;
-use std::sync::Mutex;
 use tracing::{debug, instrument};
+
+use crate::{
+    BifHandle, BifResolver, HEADER_SIZE, KeyBifEntry, KeyBifVersion, KeyEntry, KeyError, KeyResult,
+    KeyTable, LoadedBif, VariableResource, WriteBifResult,
+};
 
 /// Reads a KEY file from a reader and a caller-supplied BIF resolver.
 ///
-/// The resolver is stored for lazy BIF loading and is only invoked when a referenced resource
-/// is actually demanded.
+/// The resolver is stored for lazy BIF loading and is only invoked when a
+/// referenced resource is actually demanded.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_key_table<R>(
     reader: R,
@@ -30,7 +34,8 @@ where
     read_key_table_from_reader(reader, label.into(), resolver)
 }
 
-/// Opens a KEY file from disk and resolves BIF paths relative to the KEY directory.
+/// Opens a KEY file from disk and resolves BIF paths relative to the KEY
+/// directory.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_key_table_from_file(path: impl AsRef<Path>) -> KeyResult<KeyTable> {
     let path = path.as_ref();
@@ -118,11 +123,11 @@ where
         reader.seek(SeekFrom::Start(io_start + u64::from(*filename_offset)))?;
         let filename = trim_trailing_nuls(&read_bytes(&mut reader, usize::from(*filename_size))?);
         bifs.push(BifHandle {
-            filename: normalize_bif_filename(&filename),
+            filename:         normalize_bif_filename(&filename),
             expected_version: version,
-            expected_oid: oid.clone(),
-            resolver: resolver.clone(),
-            loaded: Mutex::new(None),
+            expected_oid:     oid.clone(),
+            resolver:         resolver.clone(),
+            loaded:           Mutex::new(None),
         });
     }
 
@@ -147,7 +152,13 @@ where
         };
 
         let rr = new_res_ref(res_ref_raw, ResType(res_type))?;
-        resref_id_lookup.insert(rr, KeyEntry { res_id, sha1 });
+        resref_id_lookup.insert(
+            rr,
+            KeyEntry {
+                res_id,
+                sha1,
+            },
+        );
     }
 
     Ok(KeyTable {
@@ -251,9 +262,9 @@ pub(crate) fn read_bif(
 #[allow(clippy::too_many_arguments)]
 /// Writes a KEY file together with its referenced BIF files.
 ///
-/// `bifs` controls both the emitted BIF set and their resource order. For each resource,
-/// `writer` must write the raw payload bytes and return the uncompressed size together with
-/// the payload SHA-1.
+/// `bifs` controls both the emitted BIF set and their resource order. For each
+/// resource, `writer` must write the raw payload bytes and return the
+/// uncompressed size together with the payload SHA-1.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/key/src/lib.rs
+++ b/crates/key/src/lib.rs
@@ -1,12 +1,13 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for KEY/BIF resource sets.
 //!
-//! KEY files index one or more BIF files and provide the canonical base-game lookup table used
-//! by NWN installations. This crate opens KEY files, lazily resolves the referenced BIFs, and
-//! exposes the aggregate result as a [`KeyTable`] implementing [`nwn_resman::ResContainer`].
+//! KEY files index one or more BIF files and provide the canonical base-game
+//! lookup table used by NWN installations. This crate opens KEY files, lazily
+//! resolves the referenced BIFs, and exposes the aggregate result as a
+//! [`KeyTable`] implementing [`nwn_resman::ResContainer`].
 //!
-//! The main entry points are [`read_key_table`], [`read_key_table_from_file`], and
-//! [`write_key_and_bif`].
+//! The main entry points are [`read_key_table`], [`read_key_table_from_file`],
+//! and [`write_key_and_bif`].
 
 mod io;
 mod types;

--- a/crates/key/src/types.rs
+++ b/crates/key/src/types.rs
@@ -1,20 +1,22 @@
+use std::{
+    fmt, io,
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+
 use indexmap::IndexMap;
 use nwn_checksums::SecureHash;
 use nwn_compressedbuf::CompressedBufError;
 use nwn_exo::ExoResFileCompressionType;
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult, SharedReadSeek, new_res_origin};
 use nwn_resref::{ResRef, ResRefError};
-use std::fmt;
-use std::io;
-use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
 
 pub(crate) const HEADER_SIZE: u64 = 64;
 
 /// Packed KEY resource id.
 ///
-/// The upper bits identify the owning BIF and the lower bits identify the variable resource
-/// within that BIF.
+/// The upper bits identify the owning BIF and the lower bits identify the
+/// variable resource within that BIF.
 pub type ResId = u32;
 /// Callback used to open a referenced BIF by filename.
 pub type BifResolver =
@@ -87,17 +89,18 @@ pub type KeyResult<T> = Result<T, KeyError>;
 pub enum KeyBifVersion {
     /// Legacy KEY/BIF layout.
     V1,
-    /// Enhanced-edition KEY/BIF layout with optional compression metadata and OID support.
+    /// Enhanced-edition KEY/BIF layout with optional compression metadata and
+    /// OID support.
     E1,
 }
 
 #[derive(Debug, Clone)]
 /// Metadata for a variable resource entry stored inside a BIF.
 pub struct VariableResource {
-    pub(crate) id: ResId,
-    pub(crate) io_offset: u64,
-    pub(crate) io_size: usize,
-    pub(crate) compression_type: ExoResFileCompressionType,
+    pub(crate) id:                ResId,
+    pub(crate) io_offset:         u64,
+    pub(crate) io_size:           usize,
+    pub(crate) compression_type:  ExoResFileCompressionType,
     pub(crate) uncompressed_size: usize,
 }
 
@@ -129,11 +132,11 @@ impl VariableResource {
 }
 
 pub(crate) struct LoadedBif {
-    pub stream: SharedReadSeek,
-    pub file_type: String,
-    pub file_version: KeyBifVersion,
+    pub stream:             SharedReadSeek,
+    pub file_type:          String,
+    pub file_version:       KeyBifVersion,
     pub variable_resources: IndexMap<ResId, VariableResource>,
-    pub oid: Option<String>,
+    pub oid:                Option<String>,
 }
 
 impl fmt::Debug for LoadedBif {
@@ -148,11 +151,11 @@ impl fmt::Debug for LoadedBif {
 }
 
 pub(crate) struct BifHandle {
-    pub filename: String,
+    pub filename:         String,
     pub expected_version: KeyBifVersion,
-    pub expected_oid: Option<String>,
-    pub resolver: BifResolver,
-    pub loaded: Mutex<Option<Arc<LoadedBif>>>,
+    pub expected_oid:     Option<String>,
+    pub resolver:         BifResolver,
+    pub loaded:           Mutex<Option<Arc<LoadedBif>>>,
 }
 
 impl fmt::Debug for BifHandle {
@@ -168,28 +171,28 @@ impl fmt::Debug for BifHandle {
 #[derive(Debug, Clone)]
 pub(crate) struct KeyEntry {
     pub res_id: ResId,
-    pub sha1: SecureHash,
+    pub sha1:   SecureHash,
 }
 
 /// Decoded contents of a KEY file together with lazy BIF resolvers.
 ///
-/// The table implements [`nwn_resman::ResContainer`], so it can be placed directly inside a
-/// layered [`nwn_resman::ResMan`].
+/// The table implements [`nwn_resman::ResContainer`], so it can be placed
+/// directly inside a layered [`nwn_resman::ResMan`].
 pub struct KeyTable {
-    pub(crate) version: KeyBifVersion,
-    pub(crate) label: String,
-    pub(crate) build_year: u32,
-    pub(crate) build_day: u32,
-    pub(crate) bifs: Vec<BifHandle>,
+    pub(crate) version:          KeyBifVersion,
+    pub(crate) label:            String,
+    pub(crate) build_year:       u32,
+    pub(crate) build_day:        u32,
+    pub(crate) bifs:             Vec<BifHandle>,
     pub(crate) resref_id_lookup: IndexMap<ResRef, KeyEntry>,
-    pub(crate) oid: Option<String>,
+    pub(crate) oid:              Option<String>,
 }
 
 #[derive(Debug, Clone)]
 /// The resources stored in a single BIF referenced by a [`KeyTable`].
 pub struct KeyBifContents {
     /// The BIF filename as recorded by the KEY file.
-    pub filename: String,
+    pub filename:  String,
     /// The resources stored in that BIF, in table order.
     pub resources: Vec<ResRef>,
 }
@@ -299,7 +302,8 @@ impl KeyTable {
 
     /// Returns the resources grouped by BIF.
     ///
-    /// Calling this may lazily open referenced BIF files through the configured resolver.
+    /// Calling this may lazily open referenced BIF files through the configured
+    /// resolver.
     pub fn bif_contents(&self) -> KeyResult<Vec<KeyBifContents>> {
         let mut by_bif = Vec::with_capacity(self.bifs.len());
 
@@ -374,9 +378,9 @@ pub struct KeyBifEntry {
     /// Optional directory component to prepend to the emitted BIF path.
     pub directory: String,
     /// Basename of the emitted BIF, without the `.bif` suffix.
-    pub name: String,
+    pub name:      String,
     /// Resource entries that should be written into the BIF.
-    pub entries: Vec<ResRef>,
+    pub entries:   Vec<ResRef>,
 }
 
 pub(crate) type WriteBifResult = (usize, Vec<(ResRef, SecureHash)>);

--- a/crates/lru/src/cache.rs
+++ b/crates/lru/src/cache.rs
@@ -1,7 +1,8 @@
-use crate::{Entry, Weight, WeightedLru};
-use std::fmt;
-use std::hash::Hash;
+use std::{fmt, hash::Hash};
+
 use tracing::{debug, instrument};
+
+use crate::{Entry, Weight, WeightedLru};
 
 impl<K, V> WeightedLru<K, V>
 where
@@ -40,7 +41,8 @@ where
         Some(&entry.value)
     }
 
-    /// Returns the cached value for `key`, inserting one with an explicit weight if needed.
+    /// Returns the cached value for `key`, inserting one with an explicit
+    /// weight if needed.
     #[instrument(level = "debug", skip_all)]
     pub fn get_or_put_with_weight<F>(&mut self, key: K, when_missing: F) -> &V
     where
@@ -61,7 +63,8 @@ where
         }
     }
 
-    /// Returns the cached value for `key`, inserting one with weight `1` if needed.
+    /// Returns the cached value for `key`, inserting one with weight `1` if
+    /// needed.
     #[instrument(level = "debug", skip_all)]
     pub fn get_or_put<F>(&mut self, key: K, when_missing: F) -> &V
     where

--- a/crates/lru/src/lib.rs
+++ b/crates/lru/src/lib.rs
@@ -1,11 +1,12 @@
 #![forbid(unsafe_code)]
 //! Minimal weighted least-recently-used cache.
 //!
-//! The cache is small on purpose: it tracks insertion order, access count, and total weight,
-//! which is sufficient for the resource-manager and TLK caches elsewhere in the workspace.
+//! The cache is small on purpose: it tracks insertion order, access count, and
+//! total weight, which is sufficient for the resource-manager and TLK caches
+//! elsewhere in the workspace.
 //!
-//! Use [`WeightedLru`] when eviction should be based on approximate byte size rather than item
-//! count alone.
+//! Use [`WeightedLru`] when eviction should be based on approximate byte size
+//! rather than item count alone.
 
 mod cache;
 mod types;

--- a/crates/lru/src/types.rs
+++ b/crates/lru/src/types.rs
@@ -5,17 +5,17 @@ pub type Weight = usize;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Entry<V> {
-    pub(crate) value: V,
-    pub(crate) weight: Weight,
+    pub(crate) value:    V,
+    pub(crate) weight:   Weight,
     pub(crate) usecount: usize,
 }
 
 /// A recency-ordered cache that evicts by accumulated entry weight.
 #[derive(Debug, Clone)]
 pub struct WeightedLru<K, V> {
-    pub(crate) min_size: usize,
-    pub(crate) max_weight: Weight,
+    pub(crate) min_size:       usize,
+    pub(crate) max_weight:     Weight,
     pub(crate) current_weight: Weight,
-    pub(crate) order: VecDeque<K>,
-    pub(crate) entries: HashMap<K, Entry<V>>,
+    pub(crate) order:          VecDeque<K>,
+    pub(crate) entries:        HashMap<K, Entry<V>>,
 }

--- a/crates/masterlist/src/lib.rs
+++ b/crates/masterlist/src/lib.rs
@@ -1,12 +1,11 @@
 #![forbid(unsafe_code)]
 //! Async client types for the Beamdog NWN masterlist API.
 //!
-//! This crate models the JSON payloads returned by the public masterlist service and provides
-//! a few direct fetch helpers. It is intentionally thin and keeps the response schema close to
-//! the wire format.
+//! This crate models the JSON payloads returned by the public masterlist
+//! service and provides a few direct fetch helpers. It is intentionally thin
+//! and keeps the response schema close to the wire format.
 
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::{debug, info, instrument};
 
 /// The Beamdog masterlist API base URL.
@@ -27,7 +26,7 @@ pub struct Manifest {
     /// Whether the manifest is required for connecting.
     pub required: bool,
     /// The manifest content hash.
-    pub hash: String,
+    pub hash:     String,
 }
 
 /// NWSync metadata advertised by a masterlist server entry.
@@ -37,7 +36,7 @@ pub struct Nwsync {
     /// The manifests associated with the server.
     pub manifests: Vec<Manifest>,
     /// The base URL for the NWSync repository.
-    pub url: String,
+    pub url:       String,
 }
 
 /// A single Beamdog masterlist server entry.
@@ -46,74 +45,74 @@ pub struct Nwsync {
 pub struct Server {
     /// The first time the server was seen by the masterlist.
     #[serde(rename = "first_seen")]
-    pub first_seen: i64,
+    pub first_seen:         i64,
     /// The most recent advertisement timestamp.
     #[serde(rename = "last_advertisement")]
     pub last_advertisement: i64,
     /// The advertised session name.
     #[serde(rename = "session_name")]
-    pub session_name: String,
+    pub session_name:       String,
     /// The advertised module name.
     #[serde(rename = "module_name")]
-    pub module_name: String,
+    pub module_name:        String,
     /// The advertised module description.
     #[serde(rename = "module_description")]
     pub module_description: String,
     /// Whether the server is password protected.
-    pub passworded: bool,
+    pub passworded:         bool,
     /// The minimum character level.
     #[serde(rename = "min_level")]
-    pub min_level: i64,
+    pub min_level:          i64,
     /// The maximum character level.
     #[serde(rename = "max_level")]
-    pub max_level: i64,
+    pub max_level:          i64,
     /// The current player count.
     #[serde(rename = "current_players")]
-    pub current_players: i64,
+    pub current_players:    i64,
     /// The maximum supported player count.
     #[serde(rename = "max_players")]
-    pub max_players: i64,
+    pub max_players:        i64,
     /// The advertised build string.
-    pub build: String,
+    pub build:              String,
     /// The advertised revision number.
-    pub rev: i64,
+    pub rev:                i64,
     /// The PVP mode identifier.
-    pub pvp: i64,
+    pub pvp:                i64,
     /// Whether the server uses a server vault.
-    pub servervault: bool,
+    pub servervault:        bool,
     /// Whether enforce legal characters is enabled.
-    pub elc: bool,
+    pub elc:                bool,
     /// Whether item level restrictions are enabled.
-    pub ilr: bool,
+    pub ilr:                bool,
     /// Whether the server is configured for one party.
     #[serde(rename = "one_party")]
-    pub one_party: bool,
+    pub one_party:          bool,
     /// Whether players can pause the game.
     #[serde(rename = "player_pause")]
-    pub player_pause: bool,
+    pub player_pause:       bool,
     /// The operating system identifier.
-    pub os: i64,
+    pub os:                 i64,
     /// The language identifier.
-    pub language: i64,
+    pub language:           i64,
     /// The game type identifier.
     #[serde(rename = "game_type")]
-    pub game_type: i64,
+    pub game_type:          i64,
     /// The measured latency.
-    pub latency: i64,
+    pub latency:            i64,
     /// The host or IP address.
-    pub host: String,
+    pub host:               String,
     /// The host port.
-    pub port: i64,
+    pub port:               i64,
     /// The advertised key-exchange public key, if present.
     #[serde(rename = "kx_pk")]
-    pub kx_pk: Option<String>,
+    pub kx_pk:              Option<String>,
     /// The advertised signing public key, if present.
     #[serde(rename = "sign_pk")]
-    pub sign_pk: Option<String>,
+    pub sign_pk:            Option<String>,
     /// The advertised NWSync details, if present.
-    pub nwsync: Option<Nwsync>,
+    pub nwsync:             Option<Nwsync>,
     /// An optional connection hint.
-    pub connecthint: Option<String>,
+    pub connecthint:        Option<String>,
 }
 
 /// The `/me` response payload.

--- a/crates/nwsync/src/io.rs
+++ b/crates/nwsync/src/io.rs
@@ -1,14 +1,18 @@
-use crate::{
-    HASH_TREE_DEPTH, MAGIC, Manifest, ManifestEntry, ManifestError, ManifestResult, VERSION,
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{self, BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
 };
+
 use nwn_checksums::SecureHash;
 use nwn_resref::{ResRef, new_res_ref};
 use nwn_restype::ResType;
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read, Write};
-use std::path::{Path, PathBuf};
 use tracing::{debug, instrument};
+
+use crate::{
+    HASH_TREE_DEPTH, MAGIC, Manifest, ManifestEntry, ManifestError, ManifestResult, VERSION,
+};
 
 /// Returns the on-disk payload path for a hashed manifest entry.
 #[instrument(

--- a/crates/nwsync/src/lib.rs
+++ b/crates/nwsync/src/lib.rs
@@ -1,12 +1,12 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for NWSync manifest files.
 //!
-//! NWSync manifests map resource references to payload hashes and sizes. This crate handles the
-//! standalone manifest file format itself; repository access and shard lookup live in
-//! [`nwn_resnwsync`].
+//! NWSync manifests map resource references to payload hashes and sizes. This
+//! crate handles the standalone manifest file format itself; repository access
+//! and shard lookup live in [`nwn_resnwsync`].
 //!
-//! Start with [`read_manifest`], [`read_manifest_file`], [`write_manifest`], and
-//! [`write_manifest_file`].
+//! Start with [`read_manifest`], [`read_manifest_file`], [`write_manifest`],
+//! and [`write_manifest_file`].
 
 mod io;
 mod types;

--- a/crates/nwsync/src/types.rs
+++ b/crates/nwsync/src/types.rs
@@ -1,8 +1,7 @@
+use std::{collections::HashMap, fmt, io};
+
 use nwn_checksums::{ParseSecureHashError, SecureHash};
 use nwn_resref::{ResRef, ResRefError};
-use std::collections::HashMap;
-use std::fmt;
-use std::io;
 
 /// The default hash tree depth for NWSync manifests.
 pub const HASH_TREE_DEPTH: u32 = 2;
@@ -68,9 +67,9 @@ pub type ManifestResult<T> = Result<T, ManifestError>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManifestEntry {
     /// The content hash stored for this entry.
-    pub sha1: SecureHash,
+    pub sha1:   SecureHash,
     /// The uncompressed payload size.
-    pub size: u32,
+    pub size:   u32,
     /// The resource reference exposed by this entry.
     pub resref: ResRef,
 }
@@ -78,7 +77,11 @@ pub struct ManifestEntry {
 impl ManifestEntry {
     /// Creates a new manifest entry.
     pub fn new(sha1: SecureHash, size: u32, resref: ResRef) -> Self {
-        Self { sha1, size, resref }
+        Self {
+            sha1,
+            size,
+            resref,
+        }
     }
 }
 
@@ -91,10 +94,10 @@ impl fmt::Display for ManifestEntry {
 /// A parsed NWSync manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Manifest {
-    pub(crate) version: u32,
+    pub(crate) version:         u32,
     pub(crate) hash_tree_depth: u32,
     /// The manifest entries in their stored order.
-    pub entries: Vec<ManifestEntry>,
+    pub entries:                Vec<ManifestEntry>,
 }
 
 impl Default for Manifest {

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -1,9 +1,9 @@
 #![forbid(unsafe_code)]
 //! Async client types for the Beamdog NWN masterlist API.
 //!
-//! This crate models the JSON payloads returned by the public masterlist service and provides
-//! a few direct fetch helpers. It is intentionally thin and keeps the response schema close to
-//! the wire format.
+//! This crate models the JSON payloads returned by the public masterlist
+//! service and provides a few direct fetch helpers. It is intentionally thin
+//! and keeps the response schema close to the wire format.
 
 /// Common imports for consumers of this crate.
 pub mod prelude {

--- a/crates/resdir/src/lib.rs
+++ b/crates/resdir/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! Directory-backed [`nwn_resman::ResContainer`] implementation.
 //!
-//! `nwn-resdir` scans an on-disk directory tree, resolves filenames into NWN resource
-//! references, and exposes the result through the shared resource-container abstraction.
-//! Override folders and unpacked working directories are the primary use cases.
+//! `nwn-resdir` scans an on-disk directory tree, resolves filenames into NWN
+//! resource references, and exposes the result through the shared
+//! resource-container abstraction. Override folders and unpacked working
+//! directories are the primary use cases.
 
 mod read;
 mod types;

--- a/crates/resdir/src/read.rs
+++ b/crates/resdir/src/read.rs
@@ -1,15 +1,19 @@
-use crate::{ResDir, ResDirError, ResDirResult};
+use std::{
+    fs::{self, File},
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::SystemTime,
+};
+
 use indexmap::IndexMap;
 use nwn_checksums::EMPTY_SECURE_HASH;
 use nwn_exo::ExoResFileCompressionType;
 use nwn_resman::{Res, new_res_origin};
 use nwn_resref::{ResRef, ResolvedResRef};
-use std::fs::{self, File};
-use std::io;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::time::SystemTime;
 use tracing::{debug, instrument};
+
+use crate::{ResDir, ResDirError, ResDirResult};
 
 /// Reads a directory tree as a flat resource container.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]

--- a/crates/resdir/src/types.rs
+++ b/crates/resdir/src/types.rs
@@ -1,9 +1,11 @@
+use std::{
+    fmt, io,
+    path::{Path, PathBuf},
+};
+
 use indexmap::IndexMap;
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult};
 use nwn_resref::ResRef;
-use std::fmt;
-use std::io;
-use std::path::{Path, PathBuf};
 
 /// Errors returned while reading a resource directory.
 #[derive(Debug)]
@@ -58,8 +60,8 @@ impl From<nwn_resref::ResRefError> for ResDirError {
 /// A directory-backed resource container.
 #[derive(Debug, Clone)]
 pub struct ResDir {
-    pub(crate) root: PathBuf,
-    pub(crate) label: String,
+    pub(crate) root:    PathBuf,
+    pub(crate) label:   String,
     pub(crate) entries: IndexMap<ResRef, Res>,
 }
 

--- a/crates/resfile/src/lib.rs
+++ b/crates/resfile/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! Single-file [`nwn_resman::ResContainer`] implementation.
 //!
-//! This crate wraps one on-disk file as a one-entry resource container. It is useful when a
-//! caller already knows the intended [`nwn_resref::ResRef`] and wants to feed a loose file into
-//! the same APIs used for directories and archives.
+//! This crate wraps one on-disk file as a one-entry resource container. It is
+//! useful when a caller already knows the intended [`nwn_resref::ResRef`] and
+//! wants to feed a loose file into the same APIs used for directories and
+//! archives.
 
 mod read;
 mod types;

--- a/crates/resfile/src/read.rs
+++ b/crates/resfile/src/read.rs
@@ -1,14 +1,18 @@
-use crate::{ResFile, ResFileError, ResFileResult};
+use std::{
+    fs::{self, File},
+    io,
+    path::Path,
+    sync::Arc,
+    time::SystemTime,
+};
+
 use nwn_checksums::EMPTY_SECURE_HASH;
 use nwn_exo::ExoResFileCompressionType;
 use nwn_resman::{Res, new_res_origin};
 use nwn_resref::{ResRef, ResolvedResRef};
-use std::fs::{self, File};
-use std::io;
-use std::path::Path;
-use std::sync::Arc;
-use std::time::SystemTime;
 use tracing::{debug, instrument};
+
+use crate::{ResFile, ResFileError, ResFileResult};
 
 /// Reads a resource file using its filename-derived resource reference.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
@@ -46,7 +50,7 @@ pub fn read_resfile_as(path: impl AsRef<Path>, resref: ResRef) -> ResFileResult<
     );
 
     let result = ResFile {
-        path: path.to_path_buf(),
+        path:  path.to_path_buf(),
         label: label.clone(),
         entry: Res::new_with_spawner(
             new_res_origin(format!("ResFile:{label}"), origin_label),

--- a/crates/resfile/src/types.rs
+++ b/crates/resfile/src/types.rs
@@ -1,8 +1,10 @@
+use std::{
+    fmt, io,
+    path::{Path, PathBuf},
+};
+
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult};
 use nwn_resref::ResRef;
-use std::fmt;
-use std::io;
-use std::path::{Path, PathBuf};
 
 /// Errors returned while reading a single-file resource container.
 #[derive(Debug)]
@@ -57,7 +59,7 @@ impl From<nwn_resref::ResRefError> for ResFileError {
 /// A single file exposed as a one-entry resource container.
 #[derive(Debug, Clone)]
 pub struct ResFile {
-    pub(crate) path: PathBuf,
+    pub(crate) path:  PathBuf,
     pub(crate) label: String,
     pub(crate) entry: Res,
 }

--- a/crates/resfile/tests/unit/mod.rs
+++ b/crates/resfile/tests/unit/mod.rs
@@ -1,10 +1,10 @@
-use super::*;
+use std::{env, fs, time::SystemTime};
+
 use nwn_resman::ResContainer;
 use nwn_resref::new_res_ref;
 use nwn_restype::ResType;
-use std::env;
-use std::fs;
-use std::time::SystemTime;
+
+use super::*;
 
 #[test]
 fn supports_explicit_resref_override() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/resman/src/lib.rs
+++ b/crates/resman/src/lib.rs
@@ -2,11 +2,12 @@
 //! Shared resource abstraction and layered resource manager.
 //!
 //! Most crates in this workspace eventually converge on the types defined here:
-//! [`Res`] represents a single resolvable payload, [`ResContainer`] represents a source of
-//! resources, and [`ResMan`] resolves those containers in precedence order with optional LRU
-//! caching.
+//! [`Res`] represents a single resolvable payload, [`ResContainer`] represents
+//! a source of resources, and [`ResMan`] resolves those containers in
+//! precedence order with optional LRU caching.
 //!
-//! If you are integrating multiple NWN data sources, this is the crate to start with.
+//! If you are integrating multiple NWN data sources, this is the crate to start
+//! with.
 
 mod manager;
 mod types;

--- a/crates/resman/src/manager.rs
+++ b/crates/resman/src/manager.rs
@@ -1,18 +1,19 @@
-use crate::{Res, ResContainer, ResManError, ResManResult};
+use std::{collections::HashSet, fmt, sync::Arc};
+
 use nwn_lru::WeightedLru;
 use nwn_resref::{ResRef, ResolvedResRef};
-use std::collections::HashSet;
-use std::fmt;
-use std::sync::Arc;
 use tracing::instrument;
+
+use crate::{Res, ResContainer, ResManError, ResManResult};
 
 /// Layered resource manager.
 ///
-/// Containers are searched from front to back, so newly added containers take precedence over
-/// earlier ones. An optional weighted LRU cache can memoize recent lookups.
+/// Containers are searched from front to back, so newly added containers take
+/// precedence over earlier ones. An optional weighted LRU cache can memoize
+/// recent lookups.
 pub struct ResMan {
     containers: Vec<Arc<dyn ResContainer>>,
-    cache: Option<WeightedLru<ResRef, Res>>,
+    cache:      Option<WeightedLru<ResRef, Res>>,
 }
 
 impl fmt::Debug for ResMan {
@@ -27,12 +28,13 @@ impl fmt::Debug for ResMan {
 impl ResMan {
     /// Creates an empty resource manager.
     ///
-    /// `cache_size_mb` controls the optional lookup cache size in megabytes. A value of `0`
-    /// disables the manager-level cache.
+    /// `cache_size_mb` controls the optional lookup cache size in megabytes. A
+    /// value of `0` disables the manager-level cache.
     pub fn new(cache_size_mb: usize) -> Self {
         Self {
             containers: Vec::new(),
-            cache: (cache_size_mb > 0).then(|| WeightedLru::new(cache_size_mb * 1024 * 1024, 1)),
+            cache:      (cache_size_mb > 0)
+                .then(|| WeightedLru::new(cache_size_mb * 1024 * 1024, 1)),
         }
     }
 
@@ -57,7 +59,8 @@ impl ResMan {
 
     /// Resolves `rr` to the highest-precedence matching resource.
     ///
-    /// When `use_cache` is `true`, successful lookups are memoized in the manager cache.
+    /// When `use_cache` is `true`, successful lookups are memoized in the
+    /// manager cache.
     #[instrument(level = "debug", skip_all, err, fields(resref = %rr, use_cache))]
     pub fn demand(&mut self, rr: &ResRef, use_cache: bool) -> ResManResult<Res> {
         if use_cache

--- a/crates/resman/src/types.rs
+++ b/crates/resman/src/types.rs
@@ -1,14 +1,18 @@
+use std::{
+    fmt,
+    io::{self, Read, Seek, SeekFrom},
+    sync::{Arc, Mutex, MutexGuard},
+    time::SystemTime,
+};
+
 use nwn_checksums::{EMPTY_SECURE_HASH, SecureHash, secure_hash};
 use nwn_compressedbuf::{CompressedBufError, decompress_bytes};
 use nwn_exo::{EXO_RES_FILE_COMPRESSED_BUF_MAGIC, ExoResFileCompressionType};
 use nwn_resref::ResRef;
-use std::fmt;
-use std::io::{self, Read, Seek, SeekFrom};
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::SystemTime;
 use tracing::instrument;
 
-/// Maximum payload size that [`Res::read_all`] will retain in the per-resource cache.
+/// Maximum payload size that [`Res::read_all`] will retain in the per-resource
+/// cache.
 pub const MEMORY_CACHE_THRESHOLD: usize = 1024 * 1024;
 
 /// Convenience trait alias for readable, seekable streams.
@@ -68,10 +72,11 @@ pub type ResManResult<T> = Result<T, ResManError>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Human-readable origin information for a [`Res`].
 ///
-/// The origin is used for error messages and debug output rather than for identity.
+/// The origin is used for error messages and debug output rather than for
+/// identity.
 pub struct ResOrigin {
     container: String,
-    label: String,
+    label:     String,
 }
 
 impl ResOrigin {
@@ -79,7 +84,7 @@ impl ResOrigin {
     pub fn new(container: impl Into<String>, label: impl Into<String>) -> Self {
         Self {
             container: container.into(),
-            label: label.into(),
+            label:     label.into(),
         }
     }
 
@@ -111,27 +116,28 @@ pub(crate) enum ResBacking {
 
 pub(crate) struct ResMutableState {
     pub cached: bool,
-    pub cache: Vec<u8>,
-    pub sha1: SecureHash,
+    pub cache:  Vec<u8>,
+    pub sha1:   SecureHash,
 }
 
 pub(crate) struct ResInner {
-    pub mtime: SystemTime,
-    pub io_offset: u64,
-    pub io_size: i64,
-    pub resref: ResRef,
-    pub compression: ExoResFileCompressionType,
+    pub mtime:             SystemTime,
+    pub io_offset:         u64,
+    pub io_size:           i64,
+    pub resref:            ResRef,
+    pub compression:       ExoResFileCompressionType,
     pub uncompressed_size: usize,
-    pub origin: ResOrigin,
-    pub backing: ResBacking,
-    pub state: Mutex<ResMutableState>,
+    pub origin:            ResOrigin,
+    pub backing:           ResBacking,
+    pub state:             Mutex<ResMutableState>,
 }
 
 #[derive(Clone)]
 /// A lazily readable NWN resource payload.
 ///
-/// A `Res` remembers where a payload lives, how large it is, whether it must be decompressed,
-/// and how to reopen or share the underlying stream. Cloning a `Res` is cheap.
+/// A `Res` remembers where a payload lives, how large it is, whether it must be
+/// decompressed, and how to reopen or share the underlying stream. Cloning a
+/// `Res` is cheap.
 pub struct Res {
     pub(crate) inner: Arc<ResInner>,
 }
@@ -184,8 +190,8 @@ impl Res {
     #[allow(clippy::too_many_arguments)]
     /// Creates a resource backed by a stream factory.
     ///
-    /// This is useful when a caller wants each read to operate on a fresh stream instead of a
-    /// shared locked handle.
+    /// This is useful when a caller wants each read to operate on a fresh
+    /// stream instead of a shared locked handle.
     pub fn new_with_spawner(
         origin: ResOrigin,
         resref: ResRef,
@@ -265,7 +271,8 @@ impl Res {
 
     /// Returns the stored payload size in bytes.
     ///
-    /// A negative value indicates that the payload should be read until end-of-stream.
+    /// A negative value indicates that the payload should be read until
+    /// end-of-stream.
     pub fn io_size(&self) -> i64 {
         self.inner.io_size
     }
@@ -297,7 +304,8 @@ impl Res {
 
     /// Seeks the underlying stream to the start of this payload.
     ///
-    /// This is mainly useful for callers performing manual reads with [`with_stream`](Self::with_stream).
+    /// This is mainly useful for callers performing manual reads with
+    /// [`with_stream`](Self::with_stream).
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn seek(&self) -> ResManResult<()> {
         self.with_stream(|stream| {
@@ -308,7 +316,8 @@ impl Res {
 
     /// Reads the full payload, decompressing it when required.
     ///
-    /// When `use_cache` is `true`, small decoded payloads are retained in memory.
+    /// When `use_cache` is `true`, small decoded payloads are retained in
+    /// memory.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref, use_cache))]
     pub fn read_all(&self, use_cache: bool) -> ResManResult<Vec<u8>> {
         if use_cache {
@@ -337,7 +346,8 @@ impl Res {
 
     /// Returns the SHA-1 digest for the decoded payload.
     ///
-    /// If the digest was not provided by the container, it is computed lazily and cached.
+    /// If the digest was not provided by the container, it is computed lazily
+    /// and cached.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn sha1(&self) -> ResManResult<SecureHash> {
         {
@@ -355,8 +365,8 @@ impl Res {
 
     /// Runs `op` against the underlying stream.
     ///
-    /// Shared-stream resources lock the stream for the duration of the callback. Spawned
-    /// resources create a fresh stream for the call.
+    /// Shared-stream resources lock the stream for the duration of the
+    /// callback. Spawned resources create a fresh stream for the call.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn with_stream<T, F>(&self, op: F) -> ResManResult<T>
     where

--- a/crates/resmemfile/src/lib.rs
+++ b/crates/resmemfile/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! In-memory [`nwn_resman::ResContainer`] implementation.
 //!
-//! This crate turns a byte buffer into a single resource entry. It is mainly useful in tests,
-//! synthetic pipelines, and cases where a decoded or downloaded payload should be treated like
-//! any other container-backed resource.
+//! This crate turns a byte buffer into a single resource entry. It is mainly
+//! useful in tests, synthetic pipelines, and cases where a decoded or
+//! downloaded payload should be treated like any other container-backed
+//! resource.
 
 mod read;
 mod types;

--- a/crates/resmemfile/src/read.rs
+++ b/crates/resmemfile/src/read.rs
@@ -1,12 +1,12 @@
-use crate::{ResMemFile, ResMemFileResult};
+use std::{io::Cursor, sync::Arc, time::SystemTime};
+
 use nwn_checksums::EMPTY_SECURE_HASH;
 use nwn_exo::ExoResFileCompressionType;
 use nwn_resman::{Res, new_res_origin, shared_stream};
 use nwn_resref::ResRef;
-use std::io::Cursor;
-use std::sync::Arc;
-use std::time::SystemTime;
 use tracing::{debug, instrument};
+
+use crate::{ResMemFile, ResMemFileResult};
 
 /// Wraps owned bytes as a one-entry in-memory resource container.
 #[instrument(level = "debug", skip_all, err)]

--- a/crates/resmemfile/src/types.rs
+++ b/crates/resmemfile/src/types.rs
@@ -1,7 +1,7 @@
+use std::{fmt, io};
+
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult};
 use nwn_resref::ResRef;
-use std::fmt;
-use std::io;
 
 /// Errors returned while building an in-memory resource container.
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl From<ResManError> for ResMemFileError {
 pub struct ResMemFile {
     pub(crate) label: String,
     pub(crate) entry: Res,
-    pub(crate) len: usize,
+    pub(crate) len:   usize,
 }
 
 impl ResMemFile {

--- a/crates/resnwsync/src/io.rs
+++ b/crates/resnwsync/src/io.rs
@@ -1,17 +1,21 @@
-use crate::{
-    ManifestSha1, NWSYNC_COMPRESSED_BUF_MAGIC_STR, NWSync, NWSyncShard, ResNWSyncError,
-    ResNWSyncManifest, ResNWSyncResult,
+use std::{
+    collections::HashMap,
+    path::Path,
+    time::{Duration, UNIX_EPOCH},
 };
+
 use indexmap::IndexSet;
 use nwn_checksums::parse_secure_hash;
 use nwn_compressedbuf::make_magic;
 use nwn_resref::new_res_ref;
 use nwn_restype::ResType;
 use rusqlite::{Connection, OptionalExtension, params};
-use std::collections::HashMap;
-use std::path::Path;
-use std::time::{Duration, UNIX_EPOCH};
 use tracing::{debug, instrument};
+
+use crate::{
+    ManifestSha1, NWSYNC_COMPRESSED_BUF_MAGIC_STR, NWSync, NWSyncShard, ResNWSyncError,
+    ResNWSyncManifest, ResNWSyncResult,
+};
 
 /// Returns the integer magic for `NSYC` compressed buffers.
 #[instrument(level = "debug", skip_all, err)]
@@ -49,7 +53,7 @@ pub fn open_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
         }
 
         let shard = NWSyncShard {
-            id: shard_id,
+            id:   shard_id,
             path: shard_path.clone(),
         };
         let conn = Connection::open(&shard_path)?;

--- a/crates/resnwsync/src/lib.rs
+++ b/crates/resnwsync/src/lib.rs
@@ -1,11 +1,12 @@
 #![forbid(unsafe_code)]
 //! Access to NWSync repositories as resource containers.
 //!
-//! This crate opens the SQLite-backed NWSync repository layout, maps manifest hashes to shard
-//! payloads, and exposes individual manifests as [`nwn_resman::ResContainer`] values.
+//! This crate opens the SQLite-backed NWSync repository layout, maps manifest
+//! hashes to shard payloads, and exposes individual manifests as
+//! [`nwn_resman::ResContainer`] values.
 //!
-//! Use [`open_nwsync`] to open a repository and [`new_resnwsync_manifest`] to materialize a
-//! specific manifest as a container.
+//! Use [`open_nwsync`] to open a repository and [`new_resnwsync_manifest`] to
+//! materialize a specific manifest as a container.
 
 mod io;
 mod types;

--- a/crates/resnwsync/src/types.rs
+++ b/crates/resnwsync/src/types.rs
@@ -1,3 +1,11 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    io::{self, Cursor},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
 use indexmap::IndexSet;
 use nwn_checksums::{ParseSecureHashError, SecureHash};
 use nwn_compressedbuf::CompressedBufError;
@@ -5,11 +13,6 @@ use nwn_exo::ExoResFileCompressionType;
 use nwn_resman::{Res, ResContainer, ResManError, ResManResult, new_res_origin, shared_stream};
 use nwn_resref::ResRef;
 use rusqlite::{Connection, OptionalExtension};
-use std::collections::HashMap;
-use std::fmt;
-use std::io::{self, Cursor};
-use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 /// The compressed-buffer magic used by NWSync shards.
 pub const NWSYNC_COMPRESSED_BUF_MAGIC_STR: &str = "NSYC";
@@ -102,7 +105,7 @@ pub type ResRefSha1 = SecureHash;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NWSyncShard {
-    pub(crate) id: ShardId,
+    pub(crate) id:   ShardId,
     pub(crate) path: PathBuf,
 }
 
@@ -115,10 +118,10 @@ impl fmt::Display for NWSyncShard {
 /// An opened NWSync repository.
 #[derive(Debug, Clone)]
 pub struct NWSync {
-    pub(crate) root: PathBuf,
+    pub(crate) root:      PathBuf,
     pub(crate) meta_path: PathBuf,
-    pub(crate) shards: HashMap<ShardId, NWSyncShard>,
-    pub(crate) shardmap: HashMap<ResRefSha1, ShardId>,
+    pub(crate) shards:    HashMap<ShardId, NWSyncShard>,
+    pub(crate) shardmap:  HashMap<ResRefSha1, ShardId>,
 }
 
 impl NWSync {
@@ -144,7 +147,8 @@ impl NWSync {
         self.shardmap.keys().copied().collect()
     }
 
-    /// Reads a resource payload by hash, decompressing `NSYC` buffers when needed.
+    /// Reads a resource payload by hash, decompressing `NSYC` buffers when
+    /// needed.
     pub fn read_resref_data(&self, sha1: ResRefSha1) -> ResNWSyncResult<Vec<u8>> {
         let Some(shard_id) = self.shardmap.get(&sha1).copied() else {
             return Err(ResNWSyncError::msg(format!("not found: {sha1}")));
@@ -188,11 +192,11 @@ impl NWSync {
 /// A single NWSync manifest exposed as a resource container.
 #[derive(Debug, Clone)]
 pub struct ResNWSyncManifest {
-    pub(crate) nwsync: NWSync,
+    pub(crate) nwsync:        NWSync,
     pub(crate) manifest_sha1: ManifestSha1,
-    pub(crate) mtime: SystemTime,
-    pub(crate) contents: IndexSet<ResRef>,
-    pub(crate) sha1map: HashMap<ResRef, ResRefSha1>,
+    pub(crate) mtime:         SystemTime,
+    pub(crate) contents:      IndexSet<ResRef>,
+    pub(crate) sha1map:       HashMap<ResRef, ResRefSha1>,
 }
 
 impl ResNWSyncManifest {

--- a/crates/resref/src/lib.rs
+++ b/crates/resref/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! NWN resource-reference parsing and formatting.
 //!
-//! A resource reference combines a case-insensitive name with a numeric resource type. This
-//! crate validates those values, resolves known file extensions through [`nwn_restype`], and
-//! provides helpers for converting between `name.ext` filenames and typed resource references.
+//! A resource reference combines a case-insensitive name with a numeric
+//! resource type. This crate validates those values, resolves known file
+//! extensions through [`nwn_restype`], and provides helpers for converting
+//! between `name.ext` filenames and typed resource references.
 
 mod parse;
 mod types;

--- a/crates/resref/src/parse.rs
+++ b/crates/resref/src/parse.rs
@@ -1,6 +1,7 @@
-use crate::{RESREF_MAX_LENGTH, ResRef, ResRefError, ResolvedResRef};
 use nwn_restype::ResType;
 use tracing::instrument;
+
+use crate::{RESREF_MAX_LENGTH, ResRef, ResRefError, ResolvedResRef};
 
 /// Returns `true` if `value` is a valid NWN resource name.
 pub fn is_valid_resref_part1(value: &str) -> bool {

--- a/crates/resref/src/types.rs
+++ b/crates/resref/src/types.rs
@@ -1,10 +1,14 @@
-use crate::is_valid_resref_part1;
+use std::{
+    cmp::Ordering,
+    error::Error,
+    fmt,
+    hash::{Hash, Hasher},
+};
+
 use nwn_restype::{ResType, lookup_res_ext, lookup_res_type};
 use nwn_util::ExpectationError;
-use std::cmp::Ordering;
-use std::error::Error;
-use std::fmt;
-use std::hash::{Hash, Hasher};
+
+use crate::is_valid_resref_part1;
 
 /// The maximum number of bytes in the name portion of a resource reference.
 pub const RESREF_MAX_LENGTH: usize = 16;
@@ -38,14 +42,14 @@ impl From<ExpectationError> for ResRefError {
 /// An NWN resource reference consisting of a name and resource type.
 #[derive(Debug, Clone)]
 pub struct ResRef {
-    res_ref: String,
+    res_ref:  String,
     res_type: ResType,
 }
 
 /// A resource reference that has been resolved to a concrete file extension.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedResRef {
-    base: ResRef,
+    base:    ResRef,
     res_ext: String,
 }
 
@@ -58,7 +62,10 @@ impl ResRef {
             format!("'{}.{}' is not a valid resref", res_ref, res_type),
         )?;
 
-        Ok(Self { res_ref, res_type })
+        Ok(Self {
+            res_ref,
+            res_type,
+        })
     }
 
     /// Resolves this resource reference to a known file extension.

--- a/crates/restype/src/lib.rs
+++ b/crates/restype/src/lib.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 //! Registry of NWN resource types and file extensions.
 //!
-//! NWN stores resource kinds as numeric ids, while most user-facing workflows operate on file
-//! extensions. This crate bridges the two and also allows callers to register additional custom
-//! mappings when working with project-specific resource types.
+//! NWN stores resource kinds as numeric ids, while most user-facing workflows
+//! operate on file extensions. This crate bridges the two and also allows
+//! callers to register additional custom mappings when working with
+//! project-specific resource types.
 
 mod registry;
 mod types;

--- a/crates/restype/src/registry.rs
+++ b/crates/restype/src/registry.rs
@@ -1,12 +1,13 @@
-use crate::{RegisterResTypeError, ResType};
+use std::{cell::RefCell, collections::HashMap};
+
 use nwn_util::expect;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use tracing::instrument;
+
+use crate::{RegisterResTypeError, ResType};
 
 #[derive(Debug, Clone)]
 struct Registry {
-    types: HashMap<ResType, String>,
+    types:   HashMap<ResType, String>,
     reverse: HashMap<String, ResType>,
 }
 
@@ -159,7 +160,8 @@ pub fn lookup_res_ext(res_type: ResType) -> Option<String> {
     REGISTRY.with(|registry| registry.borrow().types.get(&res_type).cloned())
 }
 
-/// Returns the registered resource type for `extension`, panicking if it is unknown.
+/// Returns the registered resource type for `extension`, panicking if it is
+/// unknown.
 #[instrument(level = "debug", skip_all, fields(extension = %extension))]
 pub fn get_res_type(extension: &str) -> ResType {
     match lookup_res_type(extension) {
@@ -185,7 +187,7 @@ pub fn reset_registry_for_tests() {
 
 fn make_registry() -> Registry {
     let mut registry = Registry {
-        types: HashMap::new(),
+        types:   HashMap::new(),
         reverse: HashMap::new(),
     };
 

--- a/crates/restype/src/types.rs
+++ b/crates/restype/src/types.rs
@@ -1,7 +1,8 @@
-use crate::lookup_res_ext;
+use std::{error::Error, fmt};
+
 use nwn_util::ExpectationError;
-use std::error::Error;
-use std::fmt;
+
+use crate::lookup_res_ext;
 
 /// A numeric NWN resource type identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/ssf/src/io.rs
+++ b/crates/ssf/src/io.rs
@@ -1,7 +1,9 @@
-use crate::{ENTRY_DATA_SIZE, HEADER_MAGIC, HEADER_VERSION, SsfEntry, SsfRoot, TABLE_OFFSET};
-use nwn_util::{expect, read_bytes_or_err, read_fixed_count_seq, read_str_or_err};
 use std::io::{self, Read, Seek, SeekFrom, Write};
+
+use nwn_util::{expect, read_bytes_or_err, read_fixed_count_seq, read_str_or_err};
 use tracing::{debug, instrument};
+
+use crate::{ENTRY_DATA_SIZE, HEADER_MAGIC, HEADER_VERSION, SsfEntry, SsfRoot, TABLE_OFFSET};
 
 /// Reads an `SSF` document from `reader`.
 #[instrument(level = "debug", skip_all, err)]
@@ -51,7 +53,9 @@ pub fn read_ssf<R: Read + Seek>(reader: &mut R) -> io::Result<SsfRoot> {
         })
     })?;
 
-    let root = SsfRoot { entries };
+    let root = SsfRoot {
+        entries,
+    };
     debug!(entry_count = root.entries.len(), "read ssf");
     Ok(root)
 }

--- a/crates/ssf/src/lib.rs
+++ b/crates/ssf/src/lib.rs
@@ -1,8 +1,9 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for soundset (`SSF`) files.
 //!
-//! SSF files are small, fixed-layout tables that map soundset slots to resource references and
-//! dialog string references. This crate keeps the representation deliberately simple.
+//! SSF files are small, fixed-layout tables that map soundset slots to resource
+//! references and dialog string references. This crate keeps the representation
+//! deliberately simple.
 mod io;
 mod types;
 

--- a/crates/streamext/src/io.rs
+++ b/crates/streamext/src/io.rs
@@ -1,6 +1,8 @@
-use crate::SizePrefix;
 use std::io::{self, Read, Write};
+
 use tracing::instrument;
+
+use crate::SizePrefix;
 
 /// Reads a byte buffer prefixed by a little-endian length.
 #[instrument(

--- a/crates/streamext/src/lib.rs
+++ b/crates/streamext/src/lib.rs
@@ -1,9 +1,9 @@
 #![forbid(unsafe_code)]
 //! Stream helpers for size-prefixed binary formats.
 //!
-//! Several NWN-adjacent formats use compact little-endian length prefixes. This crate provides
-//! small generic helpers for reading and writing such values without pulling in a larger binary
-//! codec framework.
+//! Several NWN-adjacent formats use compact little-endian length prefixes. This
+//! crate provides small generic helpers for reading and writing such values
+//! without pulling in a larger binary codec framework.
 
 mod io;
 mod size_prefix;

--- a/crates/tlk/src/io.rs
+++ b/crates/tlk/src/io.rs
@@ -1,10 +1,12 @@
-use crate::{DATA_ELEMENT_SIZE, HEADER_SIZE, SingleTlk, TlkEntry, TlkError, TlkResult};
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+
 use nwn_core::{Language, StrRef};
 use nwn_lru::WeightedLru;
 use nwn_resman::{Res, shared_stream};
 use nwn_util::{from_nwn_encoding, read_bytes_or_err, to_nwn_encoding};
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use tracing::{debug, instrument};
+
+use crate::{DATA_ELEMENT_SIZE, HEADER_SIZE, SingleTlk, TlkEntry, TlkError, TlkResult};
 
 /// Reads a single-language TLK table from a reader.
 #[instrument(level = "debug", skip_all, err, fields(use_cache))]
@@ -47,7 +49,8 @@ where
 
 /// Writes a single-language TLK table.
 ///
-/// Missing string references up to [`SingleTlk::highest`] are emitted as empty entries.
+/// Missing string references up to [`SingleTlk::highest`] are emitted as empty
+/// entries.
 #[instrument(level = "debug", skip_all, err, fields(language = ?tlk.language))]
 pub fn write_single_tlk<W: Write + Seek>(writer: &mut W, tlk: &mut SingleTlk) -> TlkResult<()> {
     let max_id = u32::try_from(tlk.highest().max(0))

--- a/crates/tlk/src/lib.rs
+++ b/crates/tlk/src/lib.rs
@@ -1,11 +1,13 @@
 #![forbid(unsafe_code)]
 //! Reader, writer, and query helpers for dialog table (`TLK`) files.
 //!
-//! The TLK format stores localized string entries keyed by [`nwn_core::StrRef`]. This crate
-//! supports standalone male/female tables, overlay chains, lazy entry reads, and optional LRU
-//! caching for stream-backed access.
+//! The TLK format stores localized string entries keyed by
+//! [`nwn_core::StrRef`]. This crate supports standalone male/female tables,
+//! overlay chains, lazy entry reads, and optional LRU caching for stream-backed
+//! access.
 //!
-//! Start with [`read_single_tlk`], [`write_single_tlk`], [`SingleTlk`], and [`Tlk`].
+//! Start with [`read_single_tlk`], [`write_single_tlk`], [`SingleTlk`], and
+//! [`Tlk`].
 
 mod io;
 mod types;

--- a/crates/tlk/src/types.rs
+++ b/crates/tlk/src/types.rs
@@ -1,12 +1,15 @@
+use std::{
+    collections::HashMap,
+    fmt,
+    fs::File,
+    io::{self, Cursor},
+    path::Path,
+};
+
 use nwn_core::{Gender, Language, StrRef};
 use nwn_lru::WeightedLru;
 use nwn_resman::{Res, ResManError, SharedReadSeek};
 use nwn_util::EncodingConversionError;
-use std::collections::HashMap;
-use std::fmt;
-use std::fs::File;
-use std::io::{self, Cursor};
-use std::path::Path;
 
 /// Size of the fixed TLK header in bytes.
 pub const HEADER_SIZE: u64 = 20;
@@ -70,11 +73,11 @@ pub type TlkResult<T> = Result<T, TlkError>;
 /// A single TLK entry.
 pub struct TlkEntry {
     /// Localized text content.
-    pub text: String,
+    pub text:          String,
     /// Associated sound resource reference.
     pub sound_res_ref: String,
     /// Sound length in seconds.
-    pub sound_length: f32,
+    pub sound_length:  f32,
 }
 
 impl TlkEntry {
@@ -92,8 +95,8 @@ impl fmt::Display for TlkEntry {
 
 /// A single-language TLK table.
 ///
-/// Stream-backed instances read entries lazily and may cache decoded entries in an internal
-/// weighted LRU.
+/// Stream-backed instances read entries lazily and may cache decoded entries in
+/// an internal weighted LRU.
 pub struct SingleTlk {
     /// Language represented by the table.
     pub language: Language,
@@ -131,7 +134,7 @@ impl fmt::Debug for SingleTlk {
 /// A male/female TLK pair from one layer in a TLK chain.
 pub struct TlkPair {
     /// Male table for the layer, when present.
-    pub male: Option<SingleTlk>,
+    pub male:   Option<SingleTlk>,
     /// Female table for the layer, when present.
     pub female: Option<SingleTlk>,
 }
@@ -139,7 +142,8 @@ pub struct TlkPair {
 #[derive(Debug, Default)]
 /// Layered TLK lookup chain.
 ///
-/// Queries walk the chain in order and return the first matching entry for the requested gender.
+/// Queries walk the chain in order and return the first matching entry for the
+/// requested gender.
 pub struct Tlk {
     /// Ordered TLK layers from highest to lowest precedence.
     pub chain: Vec<TlkPair>,
@@ -149,15 +153,15 @@ impl SingleTlk {
     /// Creates an empty English TLK table.
     pub fn new() -> Self {
         Self {
-            language: Language::English,
-            static_entries: HashMap::new(),
+            language:               Language::English,
+            static_entries:         HashMap::new(),
             static_entries_highest: -1,
-            stream: None,
-            io_start_pos: 0,
-            io_entry_count: 0,
-            io_entries_offset: 0,
-            use_cache: true,
-            io_cache: None,
+            stream:                 None,
+            io_start_pos:           0,
+            io_entry_count:         0,
+            io_entries_offset:      0,
+            use_cache:              true,
+            io_cache:               None,
         }
     }
 
@@ -225,9 +229,9 @@ impl SingleTlk {
         self.set_entry(
             str_ref,
             TlkEntry {
-                text: text.into(),
+                text:          text.into(),
                 sound_res_ref: String::new(),
-                sound_length: 0.0,
+                sound_length:  0.0,
             },
         );
     }
@@ -246,7 +250,9 @@ impl Default for SingleTlk {
 impl Tlk {
     /// Creates a TLK chain from explicit layers.
     pub fn new(chain: Vec<TlkPair>) -> Self {
-        Self { chain }
+        Self {
+            chain,
+        }
     }
 
     /// Builds a TLK chain from resource pairs.
@@ -257,7 +263,7 @@ impl Tlk {
         let mut pairs = Vec::with_capacity(chain.len());
         for (male, female) in chain {
             pairs.push(TlkPair {
-                male: male
+                male:   male
                     .as_ref()
                     .map(|res| SingleTlk::from_res(res, use_cache))
                     .transpose()?,

--- a/crates/twoda/src/io.rs
+++ b/crates/twoda/src/io.rs
@@ -1,11 +1,13 @@
+use std::io::{Read, Write};
+
+use nwn_resman::Res;
+use nwn_util::{from_nwn_encoding, to_nwn_encoding};
+use tracing::{debug, instrument};
+
 use crate::{
     CELL_PADDING, CELL_PADDING_MINI, Cell, MAX_COLUMNS, TWO_DA_HEADER, TwoDa, TwoDaError,
     TwoDaResult,
 };
-use nwn_resman::Res;
-use nwn_util::{from_nwn_encoding, to_nwn_encoding};
-use std::io::{Read, Write};
-use tracing::{debug, instrument};
 
 /// Reads a `2DA V2.0` table from text.
 #[instrument(level = "debug", skip_all, err)]
@@ -79,7 +81,8 @@ pub fn read_twoda<R: Read>(mut reader: R) -> TwoDaResult<TwoDa> {
 
 /// Writes a `2DA V2.0` table to text.
 ///
-/// When `minify` is `true`, column padding is reduced to the minimum required whitespace.
+/// When `minify` is `true`, column padding is reduced to the minimum required
+/// whitespace.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/twoda/src/lib.rs
+++ b/crates/twoda/src/lib.rs
@@ -1,9 +1,9 @@
 #![forbid(unsafe_code)]
 //! Reader and writer for `2DA V2.0` tables.
 //!
-//! The representation is intentionally close to the human-edited text format: columns are named,
-//! rows are ordered, and cells are optional strings. The crate also preserves the notion of a
-//! table-wide default value.
+//! The representation is intentionally close to the human-edited text format:
+//! columns are named, rows are ordered, and cells are optional strings. The
+//! crate also preserves the notion of a table-wide default value.
 //!
 //! Use [`read_twoda`], [`write_twoda`], and [`TwoDa`] for most workflows.
 

--- a/crates/twoda/src/types.rs
+++ b/crates/twoda/src/types.rs
@@ -1,7 +1,7 @@
+use std::{fmt, io};
+
 use nwn_resman::ResManError;
 use nwn_util::EncodingConversionError;
-use std::fmt;
-use std::io;
 
 /// Canonical header string for `2DA V2.0` files.
 pub const TWO_DA_HEADER: &str = "2DA V2.0";
@@ -83,10 +83,10 @@ impl TwoDa {
     /// Creates an empty table.
     pub fn new() -> Self {
         Self {
-            default_value: None,
-            headers: Vec::new(),
+            default_value:      None,
+            headers:            Vec::new(),
             headers_for_lookup: Vec::new(),
-            rows: Vec::new(),
+            rows:               Vec::new(),
         }
     }
 
@@ -107,7 +107,8 @@ impl TwoDa {
         }
     }
 
-    /// Returns the cell at `row` and `column`, falling back to the table default.
+    /// Returns the cell at `row` and `column`, falling back to the table
+    /// default.
     pub fn cell(&self, row: usize, column: &str) -> Cell {
         let mut result = self.default_value.clone();
         if let Some(row_data) = self.rows.get(row)
@@ -123,7 +124,8 @@ impl TwoDa {
         result
     }
 
-    /// Returns the cell at `row` and `column`, substituting `default` when it is missing.
+    /// Returns the cell at `row` and `column`, substituting `default` when it
+    /// is missing.
     pub fn cell_or(&self, row: usize, column: &str, default: &str) -> String {
         self.cell(row, column)
             .unwrap_or_else(|| default.to_string())

--- a/crates/util/src/encoding.rs
+++ b/crates/util/src/encoding.rs
@@ -1,8 +1,9 @@
-use crate::{EncodingConversionError, NativeEncodingError, UnknownEncodingError};
+use std::{cell::Cell, env};
+
 use encoding_rs::{Encoding, WINDOWS_1252};
-use std::cell::Cell;
-use std::env;
 use tracing::instrument;
+
+use crate::{EncodingConversionError, NativeEncodingError, UnknownEncodingError};
 
 thread_local! {
     static NWN_ENCODING: Cell<&'static Encoding> = Cell::new(WINDOWS_1252);

--- a/crates/util/src/errors.rs
+++ b/crates/util/src/errors.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 /// An error returned when an expected condition is not met.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,7 +49,7 @@ impl Error for UnknownEncodingError {}
 /// An error returned when a text conversion fails for a configured encoding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncodingConversionError {
-    encoding: String,
+    encoding:  String,
     operation: &'static str,
 }
 

--- a/crates/util/src/io.rs
+++ b/crates/util/src/io.rs
@@ -1,6 +1,8 @@
-use crate::ExpectationError;
 use std::io::{self, Read};
+
 use tracing::instrument;
+
+use crate::ExpectationError;
 
 /// Reads exactly `size` bytes or returns the underlying IO error.
 #[instrument(level = "debug", skip_all, err, fields(size))]
@@ -35,7 +37,8 @@ where
     Ok(result)
 }
 
-/// Returns `Ok(())` when `condition` is true, otherwise an [`ExpectationError`].
+/// Returns `Ok(())` when `condition` is true, otherwise an
+/// [`ExpectationError`].
 pub fn expect(condition: bool, message: impl Into<String>) -> Result<(), ExpectationError> {
     if condition {
         Ok(())

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -1,9 +1,9 @@
 #![forbid(unsafe_code)]
 //! Shared support code used across the workspace.
 //!
-//! This crate houses the intentionally generic pieces that would otherwise be duplicated:
-//! encoding selection and conversion, IO helpers, endian swapping, and simple expectation-style
-//! errors for format validation.
+//! This crate houses the intentionally generic pieces that would otherwise be
+//! duplicated: encoding selection and conversion, IO helpers, endian swapping,
+//! and simple expectation-style errors for format validation.
 
 mod encoding;
 mod errors;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -17,7 +17,7 @@ struct_lit_width = 18
 
 # Function and method formatting
 fn_single_line = false
-fn_args_layout = "Tall"
+fn_params_layout = "Tall"
 short_array_element_width_threshold = 10
 
 # Import formatting

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -59,21 +59,15 @@ remove_nested_parens = true
 
 # Control chaining
 chain_width = 60
-chains_overflow_last = true
 
 # Control match formatting
 match_arm_leading_pipes = "Never"
 match_block_trailing_comma = false
 
-# Control closure formatting
-closure_block_indent_threshold = 1
-
 # Control where formatting
 where_single_line = false
-where_layout = "Vertical"
 
 # Control generic parameter formatting
-generics_indent = "Block"
 struct_lit_single_line = false
 
 # Control array formatting

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,6 +10,7 @@ use_field_init_shorthand = true
 
 # Control struct formatting
 struct_field_align_threshold = 20
+struct_lit_single_line = false
 struct_lit_width = 18
 
 # Function and method formatting

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -33,9 +33,6 @@ hex_literal_case = "Lower"
 format_macro_matchers = true
 format_macro_bodies = true
 
-# Control attribute formatting
-normalize_doc_attributes = true
-
 # Control blank line preservation
 blank_lines_upper_bound = 2
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -39,6 +39,9 @@ blank_lines_upper_bound = 2
 # Reorder imports and items
 reorder_impl_items = true
 
+# Control attribute formatting
+normalize_doc_attributes = true
+
 # Control trailing commas
 trailing_comma = "Vertical"
 trailing_semicolon = false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -67,9 +67,6 @@ match_block_trailing_comma = false
 # Control where formatting
 where_single_line = false
 
-# Control generic parameter formatting
-struct_lit_single_line = false
-
 # Control array formatting
 array_width = 60
 single_line_if_else_max_width = 50

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,9 +4,6 @@
 # Basic formatting
 edition = "2021"
 max_width = 100
-hard_tabs = false
-tab_spaces = 4
-newline_style = "Auto"
 
 # Use field initialization shorthand
 use_field_init_shorthand = true
@@ -43,29 +40,19 @@ normalize_doc_attributes = true
 
 # Control blank line preservation
 blank_lines_upper_bound = 2
-blank_lines_lower_bound = 0
 
 # Reorder imports and items
-reorder_imports = true
-reorder_modules = true
 reorder_impl_items = true
 
 # Control trailing commas
 trailing_comma = "Vertical"
 trailing_semicolon = false
 
-# Control parentheses
-remove_nested_parens = true
-
 # Control chaining
 chain_width = 60
 
 # Control match formatting
 match_arm_leading_pipes = "Never"
-match_block_trailing_comma = false
-
-# Control where formatting
-where_single_line = false
 
 # Control array formatting
 array_width = 60

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -13,14 +13,11 @@ struct_field_align_threshold = 20
 struct_lit_width = 18
 
 # Function and method formatting
-fn_single_line = false
 fn_params_layout = "Tall"
-short_array_element_width_threshold = 10
 
 # Import formatting
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
-imports_layout = "Mixed"
 
 # Control comment formatting
 comment_width = 80
@@ -50,9 +47,6 @@ trailing_semicolon = false
 
 # Control chaining
 chain_width = 60
-
-# Control match formatting
-match_arm_leading_pipes = "Never"
 
 # Control array formatting
 array_width = 60

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 //! WebAssembly bindings for NWN1EE types and utilities.
-//! This crate re-exports the public API of the `nwn-prelude` crate with WebAssembly bindings enabled. It is intended for use in browser-based applications that need to interact with NWN1EE data and services.
+//! This crate re-exports the public API of the `nwn-prelude` crate with
+//! WebAssembly bindings enabled. It is intended for use in browser-based
+//! applications that need to interact with NWN1EE data and services.
 
 /// Re-export the public API of the `nwn-prelude` crate.
 pub use nwn_prelude::prelude::*;


### PR DESCRIPTION
## Summary

- Fix deprecated `fn_args_layout` option, renamed to `fn_params_layout`
- Remove `struct_lit_single_line = false` then restore it after observing unintended struct literal inlining
- Remove `normalize_doc_attributes = true` to preserve `#![doc = "..."]` macro compatibility and revert affected file
- Prune options that duplicate rustfmt defaults, reducing noise in the config
- Import grouping via `group_imports = "StdExternalCrate"` reorders imports as std → external → crate across the workspace

## Test plan

- [x] Run `cargo +nightly fmt` and verify no warnings or errors
- [x] Confirm doc attributes are preserved as `#![doc = "..."]` where used
- [x] Confirm struct literals remain expanded (not inline)
- [x] Confirm import grouping is consistent across all crates
