### PR TITLE
Add file change rules for various formats and configurations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,13 +64,41 @@ masterlist:
   - changed-files:
       - any-glob-to-any-file: ["crates/meta/masterlist/**/*"]
 
+prelude:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/meta/prelude/**/*"]
+
 nwscript:
   - changed-files:
       - any-glob-to-any-file: ["crates/language/nwscript/**/*"]
 
+mdl:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/mdl/**/*"]
+
+mtr:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/mtr/**/*"]
+
 nwsync:
   - changed-files:
       - any-glob-to-any-file: ["crates/formats/nwsync/**/*"]
+
+plt:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/plt/**/*"]
+
+set:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/set/**/*"]
+
+tga:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/tga/**/*"]
+
+txi:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/txi/**/*"]
 
 resdir:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -152,6 +152,16 @@ test-support:
   - changed-files:
       - any-glob-to-any-file: ["crates/foundation/test-support/**/*"]
 
+# Assets
+assets:
+  - changed-files:
+      - any-glob-to-any-file: ["assets/**/*"]
+
+# WASM bindings
+wasm:
+  - changed-files:
+      - any-glob-to-any-file: ["wasm/**/*"]
+
 # Documentation
 documentation:
   - changed-files:
@@ -161,6 +171,9 @@ documentation:
             "cli/README.md",
             "docs/**/*",
             "**/*.md",
+            "CODE_OF_CONDUCT",
+            "LICENSE",
+            "CODEOWNERS",
           ]
 
 # CI/CD and GitHub Actions

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,6 +40,14 @@ gff:
   - changed-files:
       - any-glob-to-any-file: ["crates/formats/gff/**/*"]
 
+dds:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/dds/**/*"]
+
+git:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/formats/git/**/*"]
+
 gffjson:
   - changed-files:
       - any-glob-to-any-file: ["crates/formats/gffjson/**/*"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -167,8 +167,7 @@ documentation:
   - changed-files:
       - any-glob-to-any-file:
           [
-            "README.md",
-            "cli/README.md",
+            "**/README.md",
             "docs/**/*",
             "**/*.md",
             "CODE_OF_CONDUCT",

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -167,7 +167,6 @@ documentation:
   - changed-files:
       - any-glob-to-any-file:
           [
-            "**/README.md",
             "docs/**/*",
             "**/*.md",
             "CODE_OF_CONDUCT",

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -191,7 +191,7 @@ ci/cd:
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
-          ["Cargo.toml", "cli/Cargo.toml", "crates/*/*/Cargo.toml"]
+          ["Cargo.toml", "Cargo.lock", "cli/Cargo.toml", "crates/*/*/Cargo.toml", "wasm/Cargo.toml"]
 
 # Tests
 tests:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -202,7 +202,7 @@ tests:
 config:
   - changed-files:
       - any-glob-to-any-file:
-          [".gitignore", "rustfmt.toml", "clippy.toml", "deny.toml"]
+          [".gitignore", "rustfmt.toml", "clippy.toml", "deny.toml", "rust-toolchain.toml"]
 
 # Breaking changes (files that might indicate breaking changes)
 breaking:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -148,6 +148,10 @@ io:
   - changed-files:
       - any-glob-to-any-file: ["crates/foundation/io/**/*"]
 
+test-support:
+  - changed-files:
+      - any-glob-to-any-file: ["crates/foundation/test-support/**/*"]
+
 # Documentation
 documentation:
   - changed-files:


### PR DESCRIPTION
Introduce new rules for labeling changes in DDS, Git, Prelude, MDL, MTR, PLT, SET, TGA, TXI, test-support, assets, and WASM files. Update dependency and configuration rules to include `wasm/Cargo.toml` and `rust-toolchain.toml`.