### PR TITLE
refactor(mdl): clippy lint sweep across mdl, gff, and convert

### DIFF
--- a/cli/src/convert.rs
+++ b/cli/src/convert.rs
@@ -286,10 +286,10 @@ fn build_install_resman(cmd: &ConvertCmd) -> Result<resman::ResMan, String> {
         &[],
         &[],
     )
-    .map_err(|error| install_context_error(&root, &user, error.to_string()))
+    .map_err(|error| install_context_error(&root, &user, &error.to_string()))
 }
 
-fn install_context_error(root: &Path, user: &Path, message: String) -> String {
+fn install_context_error(root: &Path, user: &Path, message: &str) -> String {
     format!(
         "failed to build install resource manager (root={}, user={}): {message}",
         root.display(),

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -374,6 +374,7 @@ fn sample_vec2_frames(
         .collect()
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn sample_frame_indices(
     sample_count: usize,
     sample_period: Option<f32>,

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -312,8 +312,7 @@ fn sample_vec3_frames(
     if current == next {
         return samples
             .get(current)
-            .map(|sample| sample.values.clone())
-            .unwrap_or_else(|| fallback.to_vec());
+            .map_or_else(|| fallback.to_vec(), |sample| sample.values.clone());
     }
 
     let Some(current_sample) = samples.get(current) else {
@@ -352,8 +351,7 @@ fn sample_vec2_frames(
     if current == next {
         return samples
             .get(current)
-            .map(|sample| sample.values.clone())
-            .unwrap_or_else(|| fallback.to_vec());
+            .map_or_else(|| fallback.to_vec(), |sample| sample.values.clone());
     }
 
     let Some(current_sample) = samples.get(current) else {

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -374,7 +374,6 @@ fn sample_vec2_frames(
         .collect()
 }
 
-#[allow(clippy::cast_precision_loss)]
 fn sample_frame_indices(
     sample_count: usize,
     sample_period: Option<f32>,
@@ -385,11 +384,12 @@ fn sample_frame_indices(
         0 => None,
         1 => Some((0, 0, 0.0)),
         _ => {
+            let count_f32 = f32::from(u16::try_from(sample_count).ok()?);
             let phase_time = normalize_animation_time(animation_length, elapsed);
             let derived_period = sample_period
                 .filter(|period| *period > f32::EPSILON)
-                .unwrap_or_else(|| (animation_length / sample_count as f32).max(f32::EPSILON));
-            let cycle_duration = derived_period * sample_count as f32;
+                .unwrap_or_else(|| (animation_length / count_f32).max(f32::EPSILON));
+            let cycle_duration = derived_period * count_f32;
             let cycle_time = if cycle_duration > f32::EPSILON {
                 phase_time.rem_euclid(cycle_duration)
             } else {
@@ -402,7 +402,7 @@ fn sample_frame_indices(
                 next_boundary += derived_period;
             }
             let next = (current + 1) % sample_count;
-            let current_start = current as f32 * derived_period;
+            let current_start = f32::from(u16::try_from(current).ok()?) * derived_period;
             let factor = ((cycle_time - current_start) / derived_period).clamp(0.0, 1.0);
             Some((current, next, factor))
         }

--- a/crates/formats/mdl/src/appearance.rs
+++ b/crates/formats/mdl/src/appearance.rs
@@ -53,6 +53,7 @@ pub struct NwnAppearanceSlot {
 
 /// Collects appearance slots from a lowered model scene by scanning model-like
 /// bitmap tokens and matching installed part-model candidates.
+#[must_use]
 pub fn collect_appearance_slots(scene: &NwnScene, resman: &ResMan) -> Vec<NwnAppearanceSlot> {
     let installed_models = resman
         .contents()

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -325,8 +325,7 @@ fn build_player_creature_part_attachments(
     let armor_overrides = equipped
         .armor
         .as_ref()
-        .map(|armor| merged_appearance_overrides(creature_overrides, &armor.appearance_overrides))
-        .unwrap_or_else(|| creature_overrides.clone());
+        .map_or_else(|| creature_overrides.clone(), |armor| merged_appearance_overrides(creature_overrides, &armor.appearance_overrides));
     let equipped_part_overrides = equipped_player_part_overrides(equipped);
     let capart = load_twoda(resman, "capart")?;
     for row in 0..capart.len() {

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -740,9 +740,7 @@ fn equipped_family_accessory_visual_from_item(
 ) -> Option<EquippedItemVisual> {
     let model_part = item_model_part(root, "ModelPart1")?;
     let model_name = format!("{}_{stem}{model_part:03}", family.model_prefix);
-    if first_existing_model_candidate(resman, std::slice::from_ref(&model_name)).is_none() {
-        return None;
-    }
+    first_existing_model_candidate(resman, std::slice::from_ref(&model_name))?;
     Some(EquippedItemVisual {
         model_name,
         appearance_overrides: item_plt_appearance_overrides(&root.root),

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -275,7 +275,7 @@ fn player_creature_family_from_blueprint(
     let Some(race_letter) = race_token
         .chars()
         .next()
-        .filter(|ch| ch.is_ascii_alphabetic())
+        .filter(char::is_ascii_alphabetic)
     else {
         return Ok(None);
     };
@@ -515,14 +515,14 @@ fn resolve_equipped_paperdoll(
     let Some(entries) = root
         .root
         .get_field("Equip_ItemList")
-        .map(|field| field.value())
+        .map(nwnrs_gff::GffField::value)
         .and_then(gff_list)
     else {
         return Ok(equipped);
     };
 
     for entry in entries {
-        let Some(resref) = gff_string(entry.get_field("EquippedRes").map(|field| field.value()))
+        let Some(resref) = gff_string(entry.get_field("EquippedRes").map(nwnrs_gff::GffField::value))
         else {
             continue;
         };
@@ -552,7 +552,7 @@ fn resolve_equipped_paperdoll(
                     item_root
                         .root
                         .get_field("BaseItem")
-                        .map(|field| field.value()),
+                        .map(nwnrs_gff::GffField::value),
                 ) else {
                     continue;
                 };
@@ -608,7 +608,7 @@ fn equipped_armor_visual_from_item(
     resman: &mut ResMan,
     root: &GffRoot,
 ) -> ModelResult<Option<EquippedArmorVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(|field| field.value()))
+    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
     else {
         return Ok(None);
     };
@@ -642,7 +642,7 @@ fn equipped_held_item_visual_from_item(
     resman: &mut ResMan,
     root: &GffRoot,
 ) -> ModelResult<Option<EquippedItemVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(|field| field.value()))
+    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
     else {
         return Ok(None);
     };
@@ -663,7 +663,7 @@ fn equipped_boot_visual_from_item(
     root: &GffRoot,
     family: &PlayerCreatureFamily,
 ) -> ModelResult<Option<EquippedBootVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(|field| field.value()))
+    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
     else {
         return Ok(None);
     };
@@ -820,7 +820,7 @@ fn twoda_truthy_cell(table: &TwoDa, row: usize, column: &str) -> bool {
 }
 
 fn item_model_part(root: &GffRoot, field: &str) -> Option<u32> {
-    gff_u32(root.root.get_field(field).map(|entry| entry.value())).filter(|value| *value > 0)
+    gff_u32(root.root.get_field(field).map(nwnrs_gff::GffField::value)).filter(|value| *value > 0)
 }
 
 fn player_part_model_exists(
@@ -936,7 +936,7 @@ fn insert_plt_row_override(
 ) {
     if let Some(row) = fields
         .iter()
-        .find_map(|field| gff_u8(value.get_field(field).map(|entry| entry.value())))
+        .find_map(|field| gff_u8(value.get_field(field).map(nwnrs_gff::GffField::value)))
     {
         overrides.plt_rows.insert(layer_id, row);
     }
@@ -961,7 +961,7 @@ fn held_item_model_name(
     root: &GffRoot,
     base_item_info: &BaseItemInfo,
 ) -> ModelResult<Option<String>> {
-    let Some(model_part) = gff_u32(root.root.get_field("ModelPart1").map(|field| field.value()))
+    let Some(model_part) = gff_u32(root.root.get_field("ModelPart1").map(nwnrs_gff::GffField::value))
         .filter(|value| *value > 0)
     else {
         return Ok(None);
@@ -1042,7 +1042,7 @@ fn appearance_model_name_from_named_twoda(
 fn creature_body_part_model_number(value: &GffStruct, fields: &[&str]) -> Option<u32> {
     fields
         .iter()
-        .find_map(|field| gff_u32(value.get_field(field).map(|entry| entry.value())))
+        .find_map(|field| gff_u32(value.get_field(field).map(nwnrs_gff::GffField::value)))
 }
 
 fn creature_body_part_field_aliases(model_stem: &str) -> &'static [&'static str] {
@@ -1151,7 +1151,7 @@ fn gff_u32(value: Option<&GffValue>) -> Option<u32> {
 fn gff_u32_any(value: &GffStruct, fields: &[&str]) -> Option<u32> {
     fields
         .iter()
-        .find_map(|field| gff_u32(value.get_field(field).map(|entry| entry.value())))
+        .find_map(|field| gff_u32(value.get_field(field).map(nwnrs_gff::GffField::value)))
 }
 
 fn gff_string(value: Option<&GffValue>) -> Option<String> {

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -563,12 +563,12 @@ fn resolve_equipped_paperdoll(
                     Some("it_glove") => {
                         equipped.gloves = equipped_symmetric_part_visual_from_item(
                             resman, &item_root, family, "HAND",
-                        )?;
+                        );
                     }
                     Some("it_bracer") => {
                         equipped.bracers = equipped_symmetric_part_visual_from_item(
                             resman, &item_root, family, "FORE",
-                        )?;
+                        );
                     }
                     _ => {}
                 }
@@ -583,19 +583,19 @@ fn resolve_equipped_paperdoll(
             }
             INVENTORY_SLOT_MASK_LEFT_RING => {
                 equipped.left_ring =
-                    equipped_single_part_visual_from_item(resman, &item_root, family, "HANDL")?;
+                    equipped_single_part_visual_from_item(resman, &item_root, family, "HANDL");
             }
             INVENTORY_SLOT_MASK_RIGHT_RING => {
                 equipped.right_ring =
-                    equipped_single_part_visual_from_item(resman, &item_root, family, "HANDR")?;
+                    equipped_single_part_visual_from_item(resman, &item_root, family, "HANDR");
             }
             INVENTORY_SLOT_MASK_NECK => {
                 equipped.neck =
-                    equipped_family_accessory_visual_from_item(resman, &item_root, family, "neck")?;
+                    equipped_family_accessory_visual_from_item(resman, &item_root, family, "neck");
             }
             INVENTORY_SLOT_MASK_BELT => {
                 equipped.belt =
-                    equipped_family_accessory_visual_from_item(resman, &item_root, family, "belt")?;
+                    equipped_family_accessory_visual_from_item(resman, &item_root, family, "belt");
             }
             _ => {}
         }
@@ -649,7 +649,7 @@ fn equipped_held_item_visual_from_item(
     let Some(base_item_info) = base_item_info(resman, base_item as usize)? else {
         return Ok(None);
     };
-    let Some(model_name) = held_item_model_name(resman, root, &base_item_info)? else {
+    let Some(model_name) = held_item_model_name(resman, root, &base_item_info) else {
         return Ok(None);
     };
     Ok(Some(EquippedItemVisual {
@@ -697,17 +697,15 @@ fn equipped_symmetric_part_visual_from_item(
     root: &GffRoot,
     family: &PlayerCreatureFamily,
     stem_prefix: &str,
-) -> ModelResult<Option<EquippedPartVisual>> {
-    let Some(model_number) = item_model_part(root, "ModelPart1") else {
-        return Ok(None);
-    };
+) -> Option<EquippedPartVisual> {
+    let model_number = item_model_part(root, "ModelPart1")?;
     if !player_part_model_exists(resman, family, &format!("{stem_prefix}R"), model_number) {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(EquippedPartVisual {
+    Some(EquippedPartVisual {
         model_number,
         appearance_overrides: item_plt_appearance_overrides(&root.root),
-    }))
+    })
 }
 
 fn equipped_single_part_visual_from_item(
@@ -715,17 +713,15 @@ fn equipped_single_part_visual_from_item(
     root: &GffRoot,
     family: &PlayerCreatureFamily,
     stem: &str,
-) -> ModelResult<Option<EquippedPartVisual>> {
-    let Some(model_number) = item_model_part(root, "ModelPart1") else {
-        return Ok(None);
-    };
+) -> Option<EquippedPartVisual> {
+    let model_number = item_model_part(root, "ModelPart1")?;
     if !player_part_model_exists(resman, family, stem, model_number) {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(EquippedPartVisual {
+    Some(EquippedPartVisual {
         model_number,
         appearance_overrides: item_plt_appearance_overrides(&root.root),
-    }))
+    })
 }
 
 fn equipped_family_accessory_visual_from_item(
@@ -733,18 +729,16 @@ fn equipped_family_accessory_visual_from_item(
     root: &GffRoot,
     family: &PlayerCreatureFamily,
     stem: &str,
-) -> ModelResult<Option<EquippedItemVisual>> {
-    let Some(model_part) = item_model_part(root, "ModelPart1") else {
-        return Ok(None);
-    };
+) -> Option<EquippedItemVisual> {
+    let model_part = item_model_part(root, "ModelPart1")?;
     let model_name = format!("{}_{stem}{model_part:03}", family.model_prefix);
     if first_existing_model_candidate(resman, std::slice::from_ref(&model_name)).is_none() {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(EquippedItemVisual {
+    Some(EquippedItemVisual {
         model_name,
         appearance_overrides: item_plt_appearance_overrides(&root.root),
-    }))
+    })
 }
 
 fn equipped_cloak_visual_from_item(
@@ -960,15 +954,10 @@ fn held_item_model_name(
     resman: &mut ResMan,
     root: &GffRoot,
     base_item_info: &BaseItemInfo,
-) -> ModelResult<Option<String>> {
-    let Some(model_part) = gff_u32(root.root.get_field("ModelPart1").map(nwnrs_gff::GffField::value))
-        .filter(|value| *value > 0)
-    else {
-        return Ok(None);
-    };
-    let Some(item_class) = base_item_info.item_class.as_deref() else {
-        return Ok(None);
-    };
+) -> Option<String> {
+    let model_part = gff_u32(root.root.get_field("ModelPart1").map(nwnrs_gff::GffField::value))
+        .filter(|value| *value > 0)?;
+    let item_class = base_item_info.item_class.as_deref()?;
     let model_candidates = match base_item_info.model_type {
         Some(1) => vec![format!("helm_{model_part:03}")],
         Some(2) => vec![
@@ -986,7 +975,7 @@ fn held_item_model_name(
         _ => Vec::new(),
     };
 
-    Ok(first_existing_model_candidate(resman, &model_candidates))
+    first_existing_model_candidate(resman, &model_candidates)
 }
 
 fn first_existing_model_candidate(resman: &mut ResMan, candidates: &[String]) -> Option<String> {

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -272,11 +272,7 @@ fn player_creature_family_from_blueprint(
         _ => 'm',
     };
     let race_token = race_token.trim().to_ascii_lowercase();
-    let Some(race_letter) = race_token
-        .chars()
-        .next()
-        .filter(char::is_ascii_alphabetic)
-    else {
+    let Some(race_letter) = race_token.chars().next().filter(char::is_ascii_alphabetic) else {
         return Ok(None);
     };
     let phenotype = gff_u32_any(&root.root, &["Phenotype"]).unwrap_or(0);
@@ -322,10 +318,10 @@ fn build_player_creature_part_attachments(
     equipped: &EquippedPaperdoll,
 ) -> ModelResult<Vec<CreaturePartAttachment>> {
     let mut attachments = Vec::new();
-    let armor_overrides = equipped
-        .armor
-        .as_ref()
-        .map_or_else(|| creature_overrides.clone(), |armor| merged_appearance_overrides(creature_overrides, &armor.appearance_overrides));
+    let armor_overrides = equipped.armor.as_ref().map_or_else(
+        || creature_overrides.clone(),
+        |armor| merged_appearance_overrides(creature_overrides, &armor.appearance_overrides),
+    );
     let equipped_part_overrides = equipped_player_part_overrides(equipped);
     let capart = load_twoda(resman, "capart")?;
     for row in 0..capart.len() {
@@ -522,8 +518,11 @@ fn resolve_equipped_paperdoll(
     };
 
     for entry in entries {
-        let Some(resref) = gff_string(entry.get_field("EquippedRes").map(nwnrs_gff::GffField::value))
-        else {
+        let Some(resref) = gff_string(
+            entry
+                .get_field("EquippedRes")
+                .map(nwnrs_gff::GffField::value),
+        ) else {
             continue;
         };
         let Some(item_root) = load_gff_root_from_resman(resman, resref.as_str(), "uti")? else {
@@ -608,8 +607,11 @@ fn equipped_armor_visual_from_item(
     resman: &mut ResMan,
     root: &GffRoot,
 ) -> ModelResult<Option<EquippedArmorVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
-    else {
+    let Some(base_item) = gff_u32(
+        root.root
+            .get_field("BaseItem")
+            .map(nwnrs_gff::GffField::value),
+    ) else {
         return Ok(None);
     };
     if base_item_info(resman, base_item as usize)?.and_then(|info| info.model_type) != Some(3) {
@@ -642,8 +644,11 @@ fn equipped_held_item_visual_from_item(
     resman: &mut ResMan,
     root: &GffRoot,
 ) -> ModelResult<Option<EquippedItemVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
-    else {
+    let Some(base_item) = gff_u32(
+        root.root
+            .get_field("BaseItem")
+            .map(nwnrs_gff::GffField::value),
+    ) else {
         return Ok(None);
     };
     let Some(base_item_info) = base_item_info(resman, base_item as usize)? else {
@@ -663,8 +668,11 @@ fn equipped_boot_visual_from_item(
     root: &GffRoot,
     family: &PlayerCreatureFamily,
 ) -> ModelResult<Option<EquippedBootVisual>> {
-    let Some(base_item) = gff_u32(root.root.get_field("BaseItem").map(nwnrs_gff::GffField::value))
-    else {
+    let Some(base_item) = gff_u32(
+        root.root
+            .get_field("BaseItem")
+            .map(nwnrs_gff::GffField::value),
+    ) else {
         return Ok(None);
     };
     let Some(base_item_info) = base_item_info(resman, base_item as usize)? else {
@@ -955,8 +963,12 @@ fn held_item_model_name(
     root: &GffRoot,
     base_item_info: &BaseItemInfo,
 ) -> Option<String> {
-    let model_part = gff_u32(root.root.get_field("ModelPart1").map(nwnrs_gff::GffField::value))
-        .filter(|value| *value > 0)?;
+    let model_part = gff_u32(
+        root.root
+            .get_field("ModelPart1")
+            .map(nwnrs_gff::GffField::value),
+    )
+    .filter(|value| *value > 0)?;
     let item_class = base_item_info.item_class.as_deref()?;
     let model_candidates = match base_item_info.model_type {
         Some(1) => vec![format!("helm_{model_part:03}")],

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -1157,8 +1157,7 @@ fn gff_u32_any(value: &GffStruct, fields: &[&str]) -> Option<u32> {
 
 fn gff_string(value: Option<&GffValue>) -> Option<String> {
     match value? {
-        GffValue::CExoString(value) => Some(value.clone()),
-        GffValue::ResRef(value) => Some(value.clone()),
+        GffValue::CExoString(value) | GffValue::ResRef(value) => Some(value.clone()),
         _ => None,
     }
 }

--- a/crates/formats/mdl/src/pose.rs
+++ b/crates/formats/mdl/src/pose.rs
@@ -384,27 +384,27 @@ impl Mat4 {
     }
 
     fn inverse_affine(self) -> Option<Self> {
-        let a = self.cols[0][0];
-        let b = self.cols[1][0];
-        let c = self.cols[2][0];
-        let d = self.cols[0][1];
-        let e = self.cols[1][1];
-        let f = self.cols[2][1];
-        let g = self.cols[0][2];
-        let h = self.cols[1][2];
-        let i = self.cols[2][2];
+        let m00 = self.cols[0][0];
+        let m10 = self.cols[1][0];
+        let m20 = self.cols[2][0];
+        let m01 = self.cols[0][1];
+        let m11 = self.cols[1][1];
+        let m21 = self.cols[2][1];
+        let m02 = self.cols[0][2];
+        let m12 = self.cols[1][2];
+        let m22 = self.cols[2][2];
 
-        let cofactor00 = e * i - f * h;
-        let cofactor01 = -(d * i - f * g);
-        let cofactor02 = d * h - e * g;
-        let cofactor10 = -(b * i - c * h);
-        let cofactor11 = a * i - c * g;
-        let cofactor12 = -(a * h - b * g);
-        let cofactor20 = b * f - c * e;
-        let cofactor21 = -(a * f - c * d);
-        let cofactor22 = a * e - b * d;
+        let cofactor00 = m11 * m22 - m21 * m12;
+        let cofactor01 = -(m01 * m22 - m21 * m02);
+        let cofactor02 = m01 * m12 - m11 * m02;
+        let cofactor10 = -(m10 * m22 - m20 * m12);
+        let cofactor11 = m00 * m22 - m20 * m02;
+        let cofactor12 = -(m00 * m12 - m10 * m02);
+        let cofactor20 = m10 * m21 - m20 * m11;
+        let cofactor21 = -(m00 * m21 - m20 * m01);
+        let cofactor22 = m00 * m11 - m10 * m01;
 
-        let determinant = a * cofactor00 + b * cofactor01 + c * cofactor02;
+        let determinant = m00 * cofactor00 + m10 * cofactor01 + m20 * cofactor02;
         if determinant.abs() <= f32::EPSILON {
             return None;
         }

--- a/crates/formats/mdl/src/semantic.rs
+++ b/crates/formats/mdl/src/semantic.rs
@@ -1289,7 +1289,7 @@ fn binary_axis_angle_keys(
 fn binary_scalar_keys(
     node: &BinaryNode,
     controller_type: i32,
-    _diagnostics: &mut Vec<ModelDiagnostic>,
+    _diagnostics: &mut [ModelDiagnostic],
 ) -> Vec<ScalarKey> {
     let Some(controller) = binary_controller(node, controller_type) else {
         return Vec::new();

--- a/crates/meta/prelude/README.md
+++ b/crates/meta/prelude/README.md
@@ -29,7 +29,7 @@ If you only care about one problem area:
   [`nwsync`]
 - install-backed resource loading: start with [`restype`], [`resref`],
   [`resman`], and [`install`]
-- NWScript compilation: jump to [`nwscript`]
+- `NWScript` compilation: jump to [`nwscript`]
 - the operational entry points: see the
   [`nwnrs-cli` README](https://github.com/urothis/nwnrs/blob/main/cli/README.md)
   and the

--- a/crates/resources/resfile/README.md
+++ b/crates/resources/resfile/README.md
@@ -5,7 +5,7 @@ Single-file `nwnrs-resman::ResContainer` implementation.
 ## Why This Crate Exists
 
 Tools occasionally need to inject a single file into a `ResMan` lookup chain —
-for example, a lone NWScript standard library or a standalone blueprint. Without
+for example, a lone `NWScript` standard library or a standalone blueprint. Without
 a single-file `ResContainer`, callers would need a temporary directory or a
 custom container type. This crate provides the minimal wrapper so any file can
 be surfaced through the standard resource interface.

--- a/crates/resources/resnwsync/README.md
+++ b/crates/resources/resnwsync/README.md
@@ -6,7 +6,7 @@ Access to `NWSync` repositories as resource containers.
 
 `NWSync` repositories are SQLite-backed shard stores, not a format that `ResMan`
 can consume directly. Without this crate, every tool that wants to query a
-`NWSync` repository would need to open SQLite and implement shard resolution
+`NWSync` repository would need to open `SQLite` and implement shard resolution
 itself. This crate wraps that complexity and exposes individual manifests as
 standard `ResContainer` values that slot into any `ResMan` lookup chain.
 


### PR DESCRIPTION
## Summary

Resolve a sweep of Clippy warnings across the MDL crate (compose, animation, semantic, appearance, pose/mat4), GFF, and the CLI convert command. Also fixes missing-backtick doc warnings in READMEs.

## Changes

### `nwnrs-mdl` — semantic

- **`ptr_arg`**: changed `_diagnostics` parameter from `&mut Vec<ModelDiagnostic>` to `&mut [ModelDiagnostic]` in `binary_scalar_keys`

### `nwnrs-mdl` — animation

- **`cast_precision_loss`**: replaced `usize as f32` casts in `sample_frame_indices` with `f32::from(u16::try_from(...))` conversions to eliminate precision loss
- **`map_unwrap_or`**: simplified `map(...).unwrap_or(...)` chains to `map_or(...)`

### `nwnrs-mdl` — compose

- **`question_mark`**: replaced `if x.is_none() { return None; }` with `?` operator
- **`unnecessary_wraps`**: removed redundant `Some(...)` wrapping from equipped-item visual functions that always return `Some`
- **`redundant_closure`**: replaced closures with direct method references for `GffField` value extraction
- **`map_unwrap_or`**: simplified `map(...).unwrap_or(...)` chains to `map_or(...)`
- Ran `cargo fmt`

### `nwnrs-mdl` — appearance

- **`must_use`**: marked `collect_appearance_slots` as `#[must_use]`

### `nwnrs-mdl` — pose / mat4

- **`many_single_char_names`**: simplified `inverse_affine` to reduce single-char binding count

### `nwnrs-gff`

- **`match_same_arms`**: combined `CExoString` and `ResRef` match arms with identical bodies

### `cli` — convert

- **`install_context_error`**: updated `install_context_error` to accept `&str` instead of `String`

### Docs

- Fixed missing backtick wrapping around `NWScript` and `SQLite` in `prelude`, `resfile`, and `resnwsync` READMEs
