### PR TITLE
docs: add error handling documentation across workspace

### DIFF
--- a/crates/formats/compressedbuf/src/io.rs
+++ b/crates/formats/compressedbuf/src/io.rs
@@ -11,6 +11,10 @@ use crate::{
 
 /// Encodes a four-byte ASCII magic string into the packed integer form used by
 /// the format.
+///
+/// # Errors
+///
+/// Returns [`ExpectationError`] if `magic` is not exactly 4 bytes.
 pub fn make_magic(magic: &str) -> Result<u32, ExpectationError> {
     expect(magic.len() == 4, "magic needs to be 4 bytes exactly")?;
     let bytes: [u8; 4] = magic
@@ -21,12 +25,20 @@ pub fn make_magic(magic: &str) -> Result<u32, ExpectationError> {
 }
 
 /// Decompresses a complete compressed buffer payload from memory.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if the bytes are malformed or decompression fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn decompress_bytes(bytes: &[u8], expect_magic: u32) -> CompressedBufResult<Vec<u8>> {
     Ok(read_payload_bytes(bytes, expect_magic)?.data)
 }
 
 /// Decompresses a compressed buffer payload from `reader`.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if the data cannot be read or decompression fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn decompress_reader<R: Read>(
     reader: &mut R,
@@ -36,6 +48,10 @@ pub fn decompress_reader<R: Read>(
 }
 
 /// Reads a complete compressed-buffer payload from memory.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if the bytes are malformed or decompression fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn read_payload_bytes(
     bytes: &[u8],
@@ -48,6 +64,10 @@ pub fn read_payload_bytes(
 }
 
 /// Reads a compressed-buffer payload from `reader`.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if the data cannot be read or does not conform to the format.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn read_payload_reader<R: Read>(
     reader: &mut R,
@@ -135,6 +155,10 @@ pub fn read_payload_reader<R: Read>(
 }
 
 /// Compresses a payload in memory and returns the encoded buffer.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if compression or encoding fails.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?algorithm, magic, input_len = data.len()))]
 pub fn compress_bytes(
     data: &[u8],
@@ -146,6 +170,10 @@ pub fn compress_bytes(
 
 /// Reads all bytes from `reader`, compresses them, and writes the encoded
 /// buffer.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if reading, compression, or writing fails.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?algorithm, magic))]
 pub fn compress_reader<R: Read, W: Write>(
     writer: &mut W,
@@ -159,6 +187,10 @@ pub fn compress_reader<R: Read, W: Write>(
 }
 
 /// Compresses `data` and writes the encoded buffer to `writer`.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if compression or writing fails.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?algorithm, magic, input_len = data.len()))]
 pub fn compress_writer<W: Write + ?Sized>(
     writer: &mut W,
@@ -173,6 +205,10 @@ pub fn compress_writer<W: Write + ?Sized>(
 }
 
 /// Encodes a provenance-rich payload back into memory.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if compression or encoding fails.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?payload.algorithm, magic = payload.magic, input_len = payload.data.len()))]
 pub fn write_payload_bytes(payload: &CompressedBufPayload) -> CompressedBufResult<Vec<u8>> {
     if let Some(original_bytes) = &payload.original_bytes {
@@ -191,6 +227,10 @@ pub fn write_payload_bytes(payload: &CompressedBufPayload) -> CompressedBufResul
 }
 
 /// Encodes a provenance-rich payload to `writer`.
+///
+/// # Errors
+///
+/// Returns [`CompressedBufError`] if compression or writing fails.
 #[instrument(level = "debug", skip_all, err, fields(algorithm = ?payload.algorithm, magic = payload.magic, input_len = payload.data.len()))]
 pub fn write_payload_writer<W: Write + ?Sized>(
     writer: &mut W,

--- a/crates/formats/compressedbuf/src/io.rs
+++ b/crates/formats/compressedbuf/src/io.rs
@@ -28,7 +28,8 @@ pub fn make_magic(magic: &str) -> Result<u32, ExpectationError> {
 ///
 /// # Errors
 ///
-/// Returns [`CompressedBufError`] if the bytes are malformed or decompression fails.
+/// Returns [`CompressedBufError`] if the bytes are malformed or decompression
+/// fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn decompress_bytes(bytes: &[u8], expect_magic: u32) -> CompressedBufResult<Vec<u8>> {
     Ok(read_payload_bytes(bytes, expect_magic)?.data)
@@ -38,7 +39,8 @@ pub fn decompress_bytes(bytes: &[u8], expect_magic: u32) -> CompressedBufResult<
 ///
 /// # Errors
 ///
-/// Returns [`CompressedBufError`] if the data cannot be read or decompression fails.
+/// Returns [`CompressedBufError`] if the data cannot be read or decompression
+/// fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn decompress_reader<R: Read>(
     reader: &mut R,
@@ -51,7 +53,8 @@ pub fn decompress_reader<R: Read>(
 ///
 /// # Errors
 ///
-/// Returns [`CompressedBufError`] if the bytes are malformed or decompression fails.
+/// Returns [`CompressedBufError`] if the bytes are malformed or decompression
+/// fails.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn read_payload_bytes(
     bytes: &[u8],
@@ -67,7 +70,8 @@ pub fn read_payload_bytes(
 ///
 /// # Errors
 ///
-/// Returns [`CompressedBufError`] if the data cannot be read or does not conform to the format.
+/// Returns [`CompressedBufError`] if the data cannot be read or does not
+/// conform to the format.
 #[instrument(level = "debug", skip_all, err, fields(expect_magic))]
 pub fn read_payload_reader<R: Read>(
     reader: &mut R,

--- a/crates/formats/compressedbuf/src/types.rs
+++ b/crates/formats/compressedbuf/src/types.rs
@@ -23,7 +23,8 @@ impl Algorithm {
     ///
     /// # Errors
     ///
-    /// Returns [`CompressedBufError`] if `value` does not correspond to a known algorithm.
+    /// Returns [`CompressedBufError`] if `value` does not correspond to a known
+    /// algorithm.
     pub fn from_u32(value: u32) -> Result<Self, CompressedBufError> {
         Ok(match value {
             0 => Self::None,

--- a/crates/formats/compressedbuf/src/types.rs
+++ b/crates/formats/compressedbuf/src/types.rs
@@ -20,6 +20,10 @@ pub enum Algorithm {
 
 impl Algorithm {
     /// Converts a raw numeric marker into a compression algorithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CompressedBufError`] if `value` does not correspond to a known algorithm.
     pub fn from_u32(value: u32) -> Result<Self, CompressedBufError> {
         Ok(match value {
             0 => Self::None,

--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -141,7 +141,8 @@ impl DdsMipLevel {
     ///
     /// # Errors
     ///
-    /// Returns [`DdsError`] if the format is unsupported or the pixel data is malformed.
+    /// Returns [`DdsError`] if the format is unsupported or the pixel data is
+    /// malformed.
     pub fn decode_rgba8(&self, format: DdsFormat) -> DdsResult<Vec<u8>> {
         decode_mip_rgba8(self, format)
     }
@@ -183,7 +184,8 @@ impl DdsTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`DdsError`] if `rgba` does not match the expected length or encoding fails.
+    /// Returns [`DdsError`] if `rgba` does not match the expected length or
+    /// encoding fails.
     pub fn encode_rgba8(
         width: u32,
         height: u32,
@@ -275,7 +277,8 @@ impl DdsTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`DdsError`] if the resource is not a DDS type or the bytes cannot be parsed.
+    /// Returns [`DdsError`] if the resource is not a DDS type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> DdsResult<Self> {
         if res.resref().res_type() != DDS_RES_TYPE {
             return Err(DdsError::msg(format!(
@@ -293,7 +296,8 @@ impl DdsTexture {
 ///
 /// # Errors
 ///
-/// Returns [`DdsError`] if the data cannot be read or does not conform to the NWN DDS format.
+/// Returns [`DdsError`] if the data cannot be read or does not conform to the
+/// NWN DDS format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_dds<R: Read>(reader: &mut R) -> DdsResult<DdsTexture> {
     let mut bytes = Vec::new();

--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -122,6 +122,10 @@ pub struct DdsMipLevel {
 
 impl DdsMipLevel {
     /// Returns the total number of pixels in this mip level.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the pixel count overflows `usize`.
     pub fn pixel_count(&self) -> DdsResult<usize> {
         usize::try_from(self.width)
             .ok()
@@ -134,6 +138,10 @@ impl DdsMipLevel {
     }
 
     /// Decodes this mip level into top-left-origin RGBA8 pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the format is unsupported or the pixel data is malformed.
     pub fn decode_rgba8(&self, format: DdsFormat) -> DdsResult<Vec<u8>> {
         decode_mip_rgba8(self, format)
     }
@@ -162,12 +170,20 @@ impl DdsTexture {
     }
 
     /// Parses an NWN DDS texture directly from raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the bytes do not conform to the NWN DDS format.
     pub fn read_from_texture_bytes(bytes: &[u8]) -> DdsResult<Self> {
         parse_dds_bytes(bytes)
     }
 
     /// Encodes top-left-origin RGBA8 pixels into an NWN DDS texture with a full
     /// mip chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if `rgba` does not match the expected length or encoding fails.
     pub fn encode_rgba8(
         width: u32,
         height: u32,
@@ -222,6 +238,10 @@ impl DdsTexture {
     }
 
     /// Decodes the top-level mip into RGBA8 pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the texture has no mip levels or decoding fails.
     pub fn decode_rgba8(&self) -> DdsResult<Vec<u8>> {
         self.mip_levels
             .first()
@@ -230,6 +250,10 @@ impl DdsTexture {
     }
 
     /// Decodes a specific mip level into RGBA8 pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if `level` is out of range or decoding fails.
     pub fn decode_mip_rgba8(&self, level: usize) -> DdsResult<Vec<u8>> {
         self.mip_levels
             .get(level)
@@ -238,12 +262,20 @@ impl DdsTexture {
     }
 
     /// Reads a typed DDS texture from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> DdsResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_dds(&mut file)
     }
 
     /// Reads a typed DDS texture from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DdsError`] if the resource is not a DDS type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> DdsResult<Self> {
         if res.resref().res_type() != DDS_RES_TYPE {
             return Err(DdsError::msg(format!(
@@ -258,6 +290,10 @@ impl DdsTexture {
 }
 
 /// Reads a typed DDS texture from `reader`.
+///
+/// # Errors
+///
+/// Returns [`DdsError`] if the data cannot be read or does not conform to the NWN DDS format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_dds<R: Read>(reader: &mut R) -> DdsResult<DdsTexture> {
     let mut bytes = Vec::new();
@@ -266,6 +302,10 @@ pub fn read_dds<R: Read>(reader: &mut R) -> DdsResult<DdsTexture> {
 }
 
 /// Writes a typed NWN DDS texture to `writer`.
+///
+/// # Errors
+///
+/// Returns [`DdsError`] if the DDS data is invalid or the write fails.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -36,6 +36,10 @@ where
 }
 
 /// Opens a file from disk and reads it as an ERF-family archive.
+///
+/// # Errors
+///
+/// Returns [`ErfError`] if the file cannot be opened or parsed.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_erf_from_file(path: impl AsRef<Path>) -> ErfResult<Erf> {
     let path = path.as_ref();
@@ -47,6 +51,10 @@ pub fn read_erf_from_file(path: impl AsRef<Path>) -> ErfResult<Erf> {
 ///
 /// This is the most direct constructor when the caller already manages stream
 /// sharing.
+///
+/// # Errors
+///
+/// Returns [`ErfError`] if the data cannot be read or does not conform to an ERF-family format.
 #[instrument(level = "debug", skip_all, err, fields(path = %filename))]
 pub fn read_erf_shared(stream: SharedReadSeek, filename: String) -> ErfResult<Erf> {
     let mut io = stream

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -23,6 +23,10 @@ use crate::{
 ///
 /// The returned [`Erf`] contains lazily readable [`nwnrs_resman::Res`] entries
 /// backed by the supplied stream.
+///
+/// # Errors
+///
+/// Returns [`ErfError`] if the data cannot be read or does not conform to an ERF-family format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_erf<R>(reader: R, filename: impl Into<String>) -> ErfResult<Erf>
 where

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -26,7 +26,8 @@ use crate::{
 ///
 /// # Errors
 ///
-/// Returns [`ErfError`] if the data cannot be read or does not conform to an ERF-family format.
+/// Returns [`ErfError`] if the data cannot be read or does not conform to an
+/// ERF-family format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_erf<R>(reader: R, filename: impl Into<String>) -> ErfResult<Erf>
 where
@@ -54,7 +55,8 @@ pub fn read_erf_from_file(path: impl AsRef<Path>) -> ErfResult<Erf> {
 ///
 /// # Errors
 ///
-/// Returns [`ErfError`] if the data cannot be read or does not conform to an ERF-family format.
+/// Returns [`ErfError`] if the data cannot be read or does not conform to an
+/// ERF-family format.
 #[instrument(level = "debug", skip_all, err, fields(path = %filename))]
 pub fn read_erf_shared(stream: SharedReadSeek, filename: String) -> ErfResult<Erf> {
     let mut io = stream

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -274,7 +274,7 @@ fn read_compressed_buf_algorithm<R: Read + Seek + ?Sized>(
 ///
 /// # Errors
 ///
-/// Returns [`ErfResult`] if the write fails.
+/// Returns [`ErfError`] if the write fails.
 #[instrument(
     level = "debug",
     skip_all,
@@ -384,7 +384,7 @@ mod tests {
 ///
 /// # Errors
 ///
-/// Returns [`ErfResult`] if the write fails.
+/// Returns [`ErfError`] if the write fails.
 #[allow(clippy::too_many_arguments)]
 pub fn write_erf_with_options<W, F>(
     writer: &mut W,
@@ -428,7 +428,7 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`ErfResult`] if the write fails.
+/// Returns [`ErfError`] if the write fails.
 #[allow(clippy::too_many_arguments)]
 pub fn write_erf_archive<W>(writer: &mut W, value: &Erf) -> ErfResult<()>
 where

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -416,8 +416,12 @@ where
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Writes a decoded ERF-family archive back out using its preserved layout.
+///
+/// # Errors
+///
+/// Returns [`ErfResult`] if the write fails.
+#[allow(clippy::too_many_arguments)]
 pub fn write_erf_archive<W>(writer: &mut W, value: &Erf) -> ErfResult<()>
 where
     W: Write + Seek,

--- a/crates/formats/erf/src/io.rs
+++ b/crates/formats/erf/src/io.rs
@@ -271,6 +271,10 @@ fn read_compressed_buf_algorithm<R: Read + Seek + ?Sized>(
 /// `entries` defines the archive order. For each entry, `entry_writer` must
 /// write the raw payload bytes and return the uncompressed byte length together
 /// with the payload SHA-1.
+///
+/// # Errors
+///
+/// Returns [`ErfResult`] if the write fails.
 #[instrument(
     level = "debug",
     skip_all,
@@ -376,8 +380,12 @@ mod tests {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Writes an ERF-family archive with explicit preserved-layout options.
+///
+/// # Errors
+///
+/// Returns [`ErfResult`] if the write fails.
+#[allow(clippy::too_many_arguments)]
 pub fn write_erf_with_options<W, F>(
     writer: &mut W,
     file_type: &str,

--- a/crates/formats/gff/src/io.rs
+++ b/crates/formats/gff/src/io.rs
@@ -73,7 +73,8 @@ struct WriteFieldEntry {
 ///
 /// # Errors
 ///
-/// Returns [`GffError`] if the data cannot be read or does not conform to the GFF V3.2 format.
+/// Returns [`GffError`] if the data cannot be read or does not conform to the
+/// GFF V3.2 format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_gff_root<R: Read + Seek>(reader: &mut R) -> GffResult<GffRoot> {
     let start = reader.stream_position()?;

--- a/crates/formats/gff/src/io.rs
+++ b/crates/formats/gff/src/io.rs
@@ -70,6 +70,10 @@ struct WriteFieldEntry {
 }
 
 /// Reads a complete GFF document from `reader`.
+///
+/// # Errors
+///
+/// Returns [`GffError`] if the data cannot be read or does not conform to the GFF V3.2 format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_gff_root<R: Read + Seek>(reader: &mut R) -> GffResult<GffRoot> {
     let start = reader.stream_position()?;
@@ -146,6 +150,10 @@ pub fn read_gff_root<R: Read + Seek>(reader: &mut R) -> GffResult<GffRoot> {
 }
 
 /// Writes a complete GFF document to `writer`.
+///
+/// # Errors
+///
+/// Returns [`GffError`] if the GFF data is invalid or the write fails.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/formats/gff/src/merge.rs
+++ b/crates/formats/gff/src/merge.rs
@@ -2,6 +2,10 @@ use crate::{GffField, GffResult, GffRoot, GffStruct, GffValue};
 
 /// Applies `edited` onto `target` while retaining provenance already present on
 /// matching parsed fields and structures.
+///
+/// # Errors
+///
+/// Returns [`GffError`] if the merge cannot be applied.
 pub fn merge_root_preserving_provenance(target: &mut GffRoot, edited: &GffRoot) -> GffResult<()> {
     target.file_type.clone_from(&edited.file_type);
     target.file_version.clone_from(&edited.file_version);

--- a/crates/formats/gff/src/merge.rs
+++ b/crates/formats/gff/src/merge.rs
@@ -5,7 +5,8 @@ use crate::{GffField, GffResult, GffRoot, GffStruct, GffValue};
 ///
 /// # Errors
 ///
-/// Returns [`GffError`] if the merge cannot be applied.
+/// Currently infallible; returns `Ok(())` in all cases. The `Result` return
+/// type is reserved for future validation.
 pub fn merge_root_preserving_provenance(target: &mut GffRoot, edited: &GffRoot) -> GffResult<()> {
     target.file_type.clone_from(&edited.file_type);
     target.file_version.clone_from(&edited.file_version);

--- a/crates/formats/gff/src/types.rs
+++ b/crates/formats/gff/src/types.rs
@@ -269,6 +269,10 @@ impl GffStruct {
     }
 
     /// Inserts or replaces a labeled field.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GffError`] if `label` is not a valid GFF label.
     pub fn put_field(&mut self, label: impl Into<String>, field: GffField) -> GffResult<()> {
         let label = label.into();
         ensure_label(&label)?;
@@ -283,6 +287,10 @@ impl GffStruct {
     }
 
     /// Inserts or replaces a labeled value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GffError`] if `label` is not a valid GFF label.
     pub fn put_value(&mut self, label: impl Into<String>, value: GffValue) -> GffResult<()> {
         self.put_field(label, GffField::new(value))
     }
@@ -349,6 +357,10 @@ impl GffRoot {
     }
 
     /// Inserts or replaces a labeled value on the root structure.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GffError`] if `label` is not a valid GFF label.
     pub fn put_value(&mut self, label: impl Into<String>, value: GffValue) -> GffResult<()> {
         self.root.put_value(label, value)
     }

--- a/crates/formats/git/src/lib.rs
+++ b/crates/formats/git/src/lib.rs
@@ -116,7 +116,8 @@ impl GitFile {
     ///
     /// # Errors
     ///
-    /// Returns [`GitError`] if the resource is not a GIT type or the bytes cannot be parsed.
+    /// Returns [`GitError`] if the resource is not a GIT type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> GitResult<Self> {
         if res.resref().res_type() != GIT_RES_TYPE {
             return Err(GitError::msg(format!(
@@ -365,7 +366,8 @@ pub struct GitPlaceable {
 ///
 /// # Errors
 ///
-/// Returns [`GitError`] if the data cannot be read or does not conform to the GIT format.
+/// Returns [`GitError`] if the data cannot be read or does not conform to the
+/// GIT format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_git<R: Read + Seek>(reader: &mut R) -> GitResult<GitFile> {
     let root = read_gff_root(reader)?;

--- a/crates/formats/git/src/lib.rs
+++ b/crates/formats/git/src/lib.rs
@@ -103,12 +103,20 @@ pub struct GitFile {
 
 impl GitFile {
     /// Reads a typed `GIT` file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> GitResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_git(&mut file)
     }
 
     /// Reads a typed `GIT` file from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] if the resource is not a GIT type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> GitResult<Self> {
         if res.resref().res_type() != GIT_RES_TYPE {
             return Err(GitError::msg(format!(
@@ -354,6 +362,10 @@ pub struct GitPlaceable {
 }
 
 /// Reads a typed `GIT` file from `reader`.
+///
+/// # Errors
+///
+/// Returns [`GitError`] if the data cannot be read or does not conform to the GIT format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_git<R: Read + Seek>(reader: &mut R) -> GitResult<GitFile> {
     let root = read_gff_root(reader)?;
@@ -361,6 +373,10 @@ pub fn read_git<R: Read + Seek>(reader: &mut R) -> GitResult<GitFile> {
 }
 
 /// Parses a typed `GIT` file from a decoded [`GffRoot`].
+///
+/// # Errors
+///
+/// Returns [`GitError`] if the root file type is not `GIT `.
 pub fn parse_git_root(root: &GffRoot) -> GitResult<GitFile> {
     if root.file_type != "GIT " {
         return Err(GitError::msg(format!(
@@ -420,6 +436,10 @@ pub fn parse_git_root(root: &GffRoot) -> GitResult<GitFile> {
 ///
 /// Known typed fields are rewritten from the typed model. Unknown fields stored
 /// on per-entry raw structures are preserved.
+///
+/// # Errors
+///
+/// Returns [`GitError`] if any GFF field label is invalid.
 pub fn build_git_root(git: &GitFile) -> GitResult<GffRoot> {
     let mut root = GffRoot::new("GIT ");
 
@@ -468,6 +488,10 @@ pub fn build_git_root(git: &GitFile) -> GitResult<GffRoot> {
 /// Writes a typed `GIT` file to `writer`.
 ///
 /// This is equivalent to [`build_git_root`] followed by [`write_gff_root`].
+///
+/// # Errors
+///
+/// Returns [`GitError`] if building or writing the GFF root fails.
 #[instrument(level = "debug", skip_all, err)]
 pub fn write_git<W: Write + Seek>(writer: &mut W, git: &GitFile) -> GitResult<()> {
     let root = build_git_root(git)?;

--- a/crates/formats/git/src/lib.rs
+++ b/crates/formats/git/src/lib.rs
@@ -132,6 +132,10 @@ impl GitFile {
     }
 
     /// Reads a typed `GIT` file from a [`ResMan`] by area name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] if the resource cannot be found or parsed.
     pub fn from_resman(
         resman: &mut ResMan,
         area_name: &str,

--- a/crates/formats/key/src/io.rs
+++ b/crates/formats/key/src/io.rs
@@ -38,6 +38,10 @@ where
 
 /// Opens a KEY file from disk and resolves BIF paths relative to the KEY
 /// directory.
+///
+/// # Errors
+///
+/// Returns [`KeyError`] if the file cannot be opened or parsed.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_key_table_from_file(path: impl AsRef<Path>) -> KeyResult<KeyTable> {
     let path = path.as_ref();

--- a/crates/formats/key/src/io.rs
+++ b/crates/formats/key/src/io.rs
@@ -20,6 +20,10 @@ use crate::prelude::*;
 ///
 /// The resolver is stored for lazy BIF loading and is only invoked when a
 /// referenced resource is actually demanded.
+///
+/// # Errors
+///
+/// Returns [`KeyError`] if the data cannot be read or does not conform to the KEY format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_key_table<R>(
     reader: R,

--- a/crates/formats/key/src/io.rs
+++ b/crates/formats/key/src/io.rs
@@ -23,7 +23,8 @@ use crate::prelude::*;
 ///
 /// # Errors
 ///
-/// Returns [`KeyError`] if the data cannot be read or does not conform to the KEY format.
+/// Returns [`KeyError`] if the data cannot be read or does not conform to the
+/// KEY format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_key_table<R>(
     reader: R,

--- a/crates/formats/key/src/io.rs
+++ b/crates/formats/key/src/io.rs
@@ -278,6 +278,10 @@ pub(crate) fn read_bif(
 /// `bifs` controls both the emitted BIF set and their resource order. For each
 /// resource, `writer` must write the raw payload bytes and return the
 /// uncompressed size together with the payload SHA-1.
+///
+/// # Errors
+///
+/// Returns [`KeyResult`] if the write fails.
 #[instrument(
     level = "debug",
     skip_all,
@@ -533,6 +537,10 @@ where
 
 /// Writes a KEY/BIF resource set using provenance preserved on a loaded
 /// [`KeyTable`].
+///
+/// # Errors
+///
+/// Returns [`KeyResult`] if the write fails.
 pub fn write_key_table_archive(
     value: &KeyTable,
     dest_dir: impl AsRef<Path>,

--- a/crates/formats/key/src/io.rs
+++ b/crates/formats/key/src/io.rs
@@ -281,7 +281,7 @@ pub(crate) fn read_bif(
 ///
 /// # Errors
 ///
-/// Returns [`KeyResult`] if the write fails.
+/// Returns [`KeyError`] if the write fails.
 #[instrument(
     level = "debug",
     skip_all,
@@ -540,7 +540,7 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`KeyResult`] if the write fails.
+/// Returns [`KeyError`] if the write fails.
 pub fn write_key_table_archive(
     value: &KeyTable,
     dest_dir: impl AsRef<Path>,

--- a/crates/formats/key/src/types.rs
+++ b/crates/formats/key/src/types.rs
@@ -335,6 +335,10 @@ impl KeyTable {
     ///
     /// Calling this may lazily open referenced BIF files through the configured
     /// resolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyError`] if any referenced BIF file cannot be loaded.
     pub fn bif_contents(&self) -> KeyResult<Vec<KeyBifContents>> {
         let mut by_bif = Vec::with_capacity(self.bifs.len());
 

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -61,6 +61,10 @@ pub fn sample_scene_animation(
 
 /// Samples one scene at `time` seconds using the default animation selection
 /// policy.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if no default animation can be selected or sampling fails.
 pub fn sample_scene_default_animation(scene: &NwnScene, time: f32) -> ModelResult<NwnScene> {
     let animation = default_scene_animation(scene).ok_or_else(|| {
         ModelError::msg(format!(

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -95,6 +95,10 @@ pub fn sample_composed_scene_animation(
 
 /// Samples one composed scene tree at `time` seconds using the root scene's
 /// default animation selection policy.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if no default animation exists or sampling fails.
 pub fn sample_composed_scene_default_animation(
     scene: &NwnComposedScene,
     time: f32,

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -78,6 +78,10 @@ pub fn sample_scene_default_animation(scene: &NwnScene, time: f32) -> ModelResul
 
 /// Samples one composed scene tree at `time` seconds on the named animation.
 /// Child scenes that do not contain the animation remain in their base pose.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if sampling fails.
 pub fn sample_composed_scene_animation(
     scene: &NwnComposedScene,
     animation_name: &str,

--- a/crates/formats/mdl/src/animation.rs
+++ b/crates/formats/mdl/src/animation.rs
@@ -64,7 +64,8 @@ pub fn sample_scene_animation(
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if no default animation can be selected or sampling fails.
+/// Returns [`ModelError`] if no default animation can be selected or sampling
+/// fails.
 pub fn sample_scene_default_animation(scene: &NwnScene, time: f32) -> ModelResult<NwnScene> {
     let animation = default_scene_animation(scene).ok_or_else(|| {
         ModelError::msg(format!(

--- a/crates/formats/mdl/src/ascii.rs
+++ b/crates/formats/mdl/src/ascii.rs
@@ -404,7 +404,7 @@ pub fn read_ascii_model<R: Read>(reader: &mut R) -> ModelResult<AsciiModel> {
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the write fails.
+/// Returns [`ModelError`] if writing to the output stream fails.
 #[instrument(level = "debug", skip_all, err, fields(geometry_name = %model.geometry_name))]
 pub fn write_ascii_model<W: Write>(writer: &mut W, model: &AsciiModel) -> ModelResult<()> {
     writer.write_all(model.to_text().as_bytes())?;

--- a/crates/formats/mdl/src/ascii.rs
+++ b/crates/formats/mdl/src/ascii.rs
@@ -302,12 +302,20 @@ impl AsciiModel {
     }
 
     /// Reads an ASCII MDL model from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_ascii_model(&mut file)
     }
 
     /// Reads an ASCII MDL model from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -323,17 +331,29 @@ impl AsciiModel {
 
 impl Model {
     /// Parses the raw payload as an ASCII MDL model using Latin-1 byte mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the bytes cannot be parsed as ASCII MDL.
     pub fn parse_ascii(&self) -> ModelResult<AsciiModel> {
         parse_ascii_model_bytes(self.bytes())
     }
 }
 
 /// Parses an ASCII MDL model from raw text.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the text cannot be parsed as a valid ASCII MDL model.
 pub fn parse_ascii_model(text: &str) -> ModelResult<AsciiModel> {
     Parser::new(text).parse_model()
 }
 
 /// Lowers a compiled binary model into canonical ASCII MDL.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the binary model cannot be lowered.
 pub fn lower_binary_model_to_ascii(model: &crate::BinaryModel) -> ModelResult<AsciiModel> {
     let semantic = crate::lower_binary_model(model)?;
     Ok(lower_semantic_model_to_ascii(
@@ -347,6 +367,10 @@ pub fn lower_binary_model_to_ascii(model: &crate::BinaryModel) -> ModelResult<As
 /// This currently supports canonical ASCII produced by
 /// [`lower_binary_model_to_ascii`], which embeds reversible compiled source
 /// metadata in prefix comments.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the model has no embedded compiled source bytes.
 pub fn compile_ascii_model(model: &AsciiModel) -> ModelResult<Model> {
     let bytes = decode_compiled_source_bytes(&model.prefix).ok_or_else(|| {
         ModelError::msg(
@@ -363,6 +387,10 @@ fn parse_ascii_model_bytes(bytes: &[u8]) -> ModelResult<AsciiModel> {
 }
 
 /// Reads an ASCII MDL model from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read or parsed as ASCII MDL.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_ascii_model<R: Read>(reader: &mut R) -> ModelResult<AsciiModel> {
     let mut bytes = Vec::new();
@@ -371,6 +399,10 @@ pub fn read_ascii_model<R: Read>(reader: &mut R) -> ModelResult<AsciiModel> {
 }
 
 /// Writes a parsed ASCII MDL model using canonical indentation.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err, fields(geometry_name = %model.geometry_name))]
 pub fn write_ascii_model<W: Write>(writer: &mut W, model: &AsciiModel) -> ModelResult<()> {
     writer.write_all(model.to_text().as_bytes())?;

--- a/crates/formats/mdl/src/ascii.rs
+++ b/crates/formats/mdl/src/ascii.rs
@@ -315,7 +315,8 @@ impl AsciiModel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -344,7 +345,8 @@ impl Model {
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the text cannot be parsed as a valid ASCII MDL model.
+/// Returns [`ModelError`] if the text cannot be parsed as a valid ASCII MDL
+/// model.
 pub fn parse_ascii_model(text: &str) -> ModelResult<AsciiModel> {
     Parser::new(text).parse_model()
 }

--- a/crates/formats/mdl/src/binary.rs
+++ b/crates/formats/mdl/src/binary.rs
@@ -48,12 +48,20 @@ pub enum ParsedModel {
 
 impl ParsedModel {
     /// Reads a parsed MDL payload from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_parsed_model(&mut file)
     }
 
     /// Reads a parsed MDL payload from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -132,12 +140,20 @@ pub struct BinaryModel {
 
 impl BinaryModel {
     /// Reads a compiled binary MDL from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_binary_model(&mut file)
     }
 
     /// Reads a compiled binary MDL from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -573,11 +589,19 @@ impl Model {
     }
 
     /// Parses the raw payload into a format-dispatched model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the payload cannot be parsed.
     pub fn parse_parsed(&self) -> ModelResult<ParsedModel> {
         parse_model_bytes(self.bytes())
     }
 
     /// Parses the raw payload as a compiled binary model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the payload cannot be parsed as a compiled binary MDL.
     pub fn parse_binary(&self) -> ModelResult<BinaryModel> {
         parse_binary_model_bytes(self.bytes())
     }
@@ -597,6 +621,10 @@ pub fn detect_model_encoding(bytes: &[u8]) -> ModelEncoding {
 }
 
 /// Parses a raw MDL payload using automatic encoding detection.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the payload cannot be parsed as ASCII or compiled MDL.
 pub fn parse_model_bytes(bytes: &[u8]) -> ModelResult<ParsedModel> {
     match detect_model_encoding(bytes) {
         ModelEncoding::Ascii => {
@@ -610,6 +638,10 @@ pub fn parse_model_bytes(bytes: &[u8]) -> ModelResult<ParsedModel> {
 }
 
 /// Reads a parsed MDL payload from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read or parsed.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_parsed_model<R: Read>(reader: &mut R) -> ModelResult<ParsedModel> {
     let mut bytes = Vec::new();
@@ -618,6 +650,10 @@ pub fn read_parsed_model<R: Read>(reader: &mut R) -> ModelResult<ParsedModel> {
 }
 
 /// Writes a parsed MDL payload.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err)]
 pub fn write_parsed_model<W: Write>(writer: &mut W, model: &ParsedModel) -> ModelResult<()> {
     match model {
@@ -627,6 +663,10 @@ pub fn write_parsed_model<W: Write>(writer: &mut W, model: &ParsedModel) -> Mode
 }
 
 /// Parses a compiled binary MDL payload from raw bytes.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the bytes do not conform to the compiled MDL format.
 pub fn parse_binary_model_bytes(bytes: &[u8]) -> ModelResult<BinaryModel> {
     let header = parse_binary_header(bytes)?;
     let mut parser = BinaryParser::new(bytes, header.clone());
@@ -634,6 +674,10 @@ pub fn parse_binary_model_bytes(bytes: &[u8]) -> ModelResult<BinaryModel> {
 }
 
 /// Reads a compiled binary MDL from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read or parsed as a compiled MDL.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_binary_model<R: Read>(reader: &mut R) -> ModelResult<BinaryModel> {
     let mut bytes = Vec::new();
@@ -642,6 +686,10 @@ pub fn read_binary_model<R: Read>(reader: &mut R) -> ModelResult<BinaryModel> {
 }
 
 /// Writes a compiled binary MDL back to its original bytes.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err, fields(model_name = %model.name))]
 pub fn write_binary_model<W: Write>(writer: &mut W, model: &BinaryModel) -> ModelResult<()> {
     writer.write_all(&model.source_bytes)?;

--- a/crates/formats/mdl/src/binary.rs
+++ b/crates/formats/mdl/src/binary.rs
@@ -61,7 +61,8 @@ impl ParsedModel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -153,7 +154,8 @@ impl BinaryModel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or parsing fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or parsing
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -601,7 +603,8 @@ impl Model {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the payload cannot be parsed as a compiled binary MDL.
+    /// Returns [`ModelError`] if the payload cannot be parsed as a compiled
+    /// binary MDL.
     pub fn parse_binary(&self) -> ModelResult<BinaryModel> {
         parse_binary_model_bytes(self.bytes())
     }
@@ -624,7 +627,8 @@ pub fn detect_model_encoding(bytes: &[u8]) -> ModelEncoding {
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the payload cannot be parsed as ASCII or compiled MDL.
+/// Returns [`ModelError`] if the payload cannot be parsed as ASCII or compiled
+/// MDL.
 pub fn parse_model_bytes(bytes: &[u8]) -> ModelResult<ParsedModel> {
     match detect_model_encoding(bytes) {
         ModelEncoding::Ascii => {
@@ -666,7 +670,8 @@ pub fn write_parsed_model<W: Write>(writer: &mut W, model: &ParsedModel) -> Mode
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the bytes do not conform to the compiled MDL format.
+/// Returns [`ModelError`] if the bytes do not conform to the compiled MDL
+/// format.
 pub fn parse_binary_model_bytes(bytes: &[u8]) -> ModelResult<BinaryModel> {
     let header = parse_binary_header(bytes)?;
     let mut parser = BinaryParser::new(bytes, header.clone());
@@ -677,7 +682,8 @@ pub fn parse_binary_model_bytes(bytes: &[u8]) -> ModelResult<BinaryModel> {
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the data cannot be read or parsed as a compiled MDL.
+/// Returns [`ModelError`] if the data cannot be read or parsed as a compiled
+/// MDL.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_binary_model<R: Read>(reader: &mut R) -> ModelResult<BinaryModel> {
     let mut bytes = Vec::new();

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -154,6 +154,10 @@ pub fn load_composed_scene_from_resman(
 
 /// Composes an equipped player creature from one parsed `UTC` blueprint and
 /// resolves all attached model parts into a composed scene tree.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the appearance cannot be resolved or a model fails to load.
 pub fn compose_player_creature_from_utc(
     resman: &mut ResMan,
     root: &GffRoot,
@@ -221,6 +225,10 @@ pub fn compose_player_creature_from_utc(
 
 /// Loads a `UTC` blueprint from `resman` by resource name and composes it into
 /// an equipped player-creature scene tree.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the blueprint cannot be loaded or the creature cannot be composed.
 pub fn compose_player_creature_from_resman(
     resman: &mut ResMan,
     blueprint_name: &str,

--- a/crates/formats/mdl/src/compose.rs
+++ b/crates/formats/mdl/src/compose.rs
@@ -157,7 +157,8 @@ pub fn load_composed_scene_from_resman(
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the appearance cannot be resolved or a model fails to load.
+/// Returns [`ModelError`] if the appearance cannot be resolved or a model fails
+/// to load.
 pub fn compose_player_creature_from_utc(
     resman: &mut ResMan,
     root: &GffRoot,
@@ -228,7 +229,8 @@ pub fn compose_player_creature_from_utc(
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the blueprint cannot be loaded or the creature cannot be composed.
+/// Returns [`ModelError`] if the blueprint cannot be loaded or the creature
+/// cannot be composed.
 pub fn compose_player_creature_from_resman(
     resman: &mut ResMan,
     blueprint_name: &str,

--- a/crates/formats/mdl/src/io.rs
+++ b/crates/formats/mdl/src/io.rs
@@ -5,6 +5,10 @@ use tracing::instrument;
 use crate::{Model, ModelResult};
 
 /// Reads an `MDL` payload from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_model<R: Read>(reader: &mut R) -> ModelResult<Model> {
     let mut bytes = Vec::new();
@@ -13,6 +17,10 @@ pub fn read_model<R: Read>(reader: &mut R) -> ModelResult<Model> {
 }
 
 /// Writes an `MDL` payload to `writer`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err, fields(byte_len = model.byte_len()))]
 pub fn write_model<W: Write>(writer: &mut W, model: &Model) -> ModelResult<()> {
     writer.write_all(model.bytes())?;

--- a/crates/formats/mdl/src/obj.rs
+++ b/crates/formats/mdl/src/obj.rs
@@ -25,6 +25,10 @@ pub fn write_scene_obj<W: Write>(writer: &mut W, scene: &NwnScene) -> ModelResul
 }
 
 /// Writes one composed scene tree as a flattened Wavefront OBJ mesh.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if scene baking or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(model = %scene.model_name))]
 pub fn write_composed_scene_obj<W: Write>(
     writer: &mut W,

--- a/crates/formats/mdl/src/obj.rs
+++ b/crates/formats/mdl/src/obj.rs
@@ -9,6 +9,10 @@ use crate::{
 };
 
 /// Writes one scene as a flattened Wavefront OBJ mesh.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if scene baking or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(scene = %scene.name))]
 pub fn write_scene_obj<W: Write>(writer: &mut W, scene: &NwnScene) -> ModelResult<()> {
     let composed = NwnComposedScene {

--- a/crates/formats/mdl/src/pose.rs
+++ b/crates/formats/mdl/src/pose.rs
@@ -5,12 +5,20 @@ use crate::{
 };
 
 /// Bakes skinned meshes in one scene using the scene's current pose.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the scene pose cannot be baked.
 pub fn bake_scene_pose(scene: &NwnScene) -> ModelResult<NwnScene> {
     bake_scene_pose_with_bind_pose(scene, scene)
 }
 
 /// Bakes skinned meshes in one composed scene tree using each scene's current
 /// pose.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if any scene pose cannot be baked.
 pub fn bake_composed_scene_pose(scene: &NwnComposedScene) -> ModelResult<NwnComposedScene> {
     Ok(NwnComposedScene {
         model_name:            scene.model_name.clone(),

--- a/crates/formats/mdl/src/resolve.rs
+++ b/crates/formats/mdl/src/resolve.rs
@@ -158,6 +158,10 @@ pub fn scene_texture_resolution_names(
 
 /// Resolves one texture reference through `resman`, including scene-aware
 /// appearance fallbacks.
+///
+/// # Errors
+///
+/// Returns [`UnresolvedTexture`] if the texture cannot be found.
 pub fn resolve_scene_texture_ref(
     scene: &NwnScene,
     material: &NwnMaterial,

--- a/crates/formats/mdl/src/scene.rs
+++ b/crates/formats/mdl/src/scene.rs
@@ -90,7 +90,8 @@ impl NwnScene {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -108,7 +109,8 @@ impl NwnScene {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering
+    /// fails.
     pub fn from_auto_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(

--- a/crates/formats/mdl/src/scene.rs
+++ b/crates/formats/mdl/src/scene.rs
@@ -66,6 +66,10 @@ impl NwnScene {
     }
 
     /// Reads and lowers an engine-neutral scene from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_scene_model(&mut file)
@@ -73,12 +77,20 @@ impl NwnScene {
 
     /// Reads and lowers an engine-neutral scene from disk using automatic
     /// ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or parsed.
     pub fn from_auto_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_scene_model_auto(&mut file)
     }
 
     /// Reads and lowers an engine-neutral scene from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -93,6 +105,10 @@ impl NwnScene {
 
     /// Reads and lowers an engine-neutral scene from a [`Res`] using automatic
     /// ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
     pub fn from_auto_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -466,29 +482,49 @@ type SceneWriteOwnership = (Vec<Option<usize>>, Vec<Option<usize>>);
 
 impl Model {
     /// Parses and lowers the raw payload into an engine-neutral NWN scene.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if parsing or lowering fails.
     pub fn parse_scene(&self) -> ModelResult<NwnScene> {
         lower_semantic_model_to_scene(&self.parse_semantic()?)
     }
 
     /// Parses and lowers the raw payload into an engine-neutral NWN scene
     /// using automatic ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if parsing or lowering fails.
     pub fn parse_scene_auto(&self) -> ModelResult<NwnScene> {
         lower_semantic_model_to_scene(&self.parse_semantic_auto()?)
     }
 }
 
 /// Parses and lowers an engine-neutral scene from ASCII MDL text.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the text cannot be parsed or lowered.
 pub fn parse_scene_model(text: &str) -> ModelResult<NwnScene> {
     lower_semantic_model_to_scene(&parse_semantic_model(text)?)
 }
 
 /// Parses and lowers an engine-neutral scene from raw MDL bytes using
 /// automatic ASCII/compiled dispatch.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the bytes cannot be parsed or lowered.
 pub fn parse_scene_model_auto(bytes: &[u8]) -> ModelResult<NwnScene> {
     lower_semantic_model_to_scene(&parse_semantic_model_auto(bytes)?)
 }
 
 /// Reads and lowers an engine-neutral scene from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read or lowered.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_scene_model<R: Read>(reader: &mut R) -> ModelResult<NwnScene> {
     let semantic = read_semantic_model(reader)?;
@@ -497,6 +533,10 @@ pub fn read_scene_model<R: Read>(reader: &mut R) -> ModelResult<NwnScene> {
 
 /// Reads and lowers an engine-neutral scene from `reader` using automatic
 /// ASCII/compiled dispatch.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the data cannot be read or lowered.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_scene_model_auto<R: Read>(reader: &mut R) -> ModelResult<NwnScene> {
     let semantic = read_semantic_model_auto(reader)?;
@@ -504,6 +544,10 @@ pub fn read_scene_model_auto<R: Read>(reader: &mut R) -> ModelResult<NwnScene> {
 }
 
 /// Writes an engine-neutral scene as canonical ASCII MDL.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if raising the scene or writing fails.
 #[instrument(level = "debug", skip_all, err, fields(model_name = %scene.name))]
 pub fn write_scene_model<W: Write>(writer: &mut W, scene: &NwnScene) -> ModelResult<()> {
     let semantic = raise_scene_to_semantic(scene)?;
@@ -1171,6 +1215,10 @@ fn validate_uniform_scale(scale: &[f32; 3], context: &str) -> ModelResult<f32> {
 }
 
 /// Lowers a semantic MDL model into an engine-neutral scene representation.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the semantic model cannot be lowered into a scene.
 pub fn lower_semantic_model_to_scene(model: &SemanticModel) -> ModelResult<NwnScene> {
     let mut diagnostics = model.diagnostics.clone();
 

--- a/crates/formats/mdl/src/semantic.rs
+++ b/crates/formats/mdl/src/semantic.rs
@@ -72,12 +72,20 @@ impl SemanticModel {
 
     /// Reads and lowers a semantic model from disk using automatic
     /// ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or lowered.
     pub fn from_auto_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_semantic_model_auto(&mut file)
     }
 
     /// Reads and lowers a semantic model from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -92,6 +100,10 @@ impl SemanticModel {
 
     /// Reads and lowers a semantic model from a [`Res`] using automatic
     /// ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
     pub fn from_auto_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -541,12 +553,20 @@ pub enum ModelDiagnosticKind {
 
 impl Model {
     /// Parses and lowers the raw payload into a typed semantic model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if parsing or lowering fails.
     pub fn parse_semantic(&self) -> ModelResult<SemanticModel> {
         lower_ascii_model(&self.parse_ascii()?)
     }
 
     /// Parses and lowers the raw payload into a typed semantic model using
     /// automatic ASCII/compiled dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if parsing or lowering fails.
     pub fn parse_semantic_auto(&self) -> ModelResult<SemanticModel> {
         match self.parse_parsed()? {
             ParsedModel::Ascii(model) => lower_ascii_model(&model),
@@ -556,12 +576,20 @@ impl Model {
 }
 
 /// Parses and lowers a semantic model from ASCII MDL text.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if parsing or lowering fails.
 pub fn parse_semantic_model(text: &str) -> ModelResult<SemanticModel> {
     lower_ascii_model(&parse_ascii_model(text)?)
 }
 
 /// Parses and lowers a semantic model from raw MDL bytes using automatic
 /// ASCII/compiled dispatch.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if parsing or lowering fails.
 pub fn parse_semantic_model_auto(bytes: &[u8]) -> ModelResult<SemanticModel> {
     match crate::parse_model_bytes(bytes)? {
         ParsedModel::Ascii(model) => lower_ascii_model(&model),
@@ -570,6 +598,10 @@ pub fn parse_semantic_model_auto(bytes: &[u8]) -> ModelResult<SemanticModel> {
 }
 
 /// Reads and lowers a semantic model from `reader`.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if reading or lowering fails.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_semantic_model<R: Read>(reader: &mut R) -> ModelResult<SemanticModel> {
     let ascii = read_ascii_model(reader)?;
@@ -578,6 +610,10 @@ pub fn read_semantic_model<R: Read>(reader: &mut R) -> ModelResult<SemanticModel
 
 /// Reads and lowers a semantic model from `reader` using automatic
 /// ASCII/compiled dispatch.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if reading or lowering fails.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_semantic_model_auto<R: Read>(reader: &mut R) -> ModelResult<SemanticModel> {
     match read_parsed_model(reader)? {
@@ -587,6 +623,10 @@ pub fn read_semantic_model_auto<R: Read>(reader: &mut R) -> ModelResult<Semantic
 }
 
 /// Writes a semantic MDL model as canonical ASCII.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err, fields(model_name = %model.geometry_name))]
 pub fn write_semantic_model<W: Write>(writer: &mut W, model: &SemanticModel) -> ModelResult<()> {
     let ascii = crate::ascii::lower_semantic_model_to_ascii(model, None);
@@ -594,6 +634,10 @@ pub fn write_semantic_model<W: Write>(writer: &mut W, model: &SemanticModel) -> 
 }
 
 /// Lowers a source-faithful ASCII MDL model into typed semantic data.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if lowering fails.
 pub fn lower_ascii_model(model: &AsciiModel) -> ModelResult<SemanticModel> {
     let mut diagnostics = Vec::new();
     let header = lower_header(model, &mut diagnostics);

--- a/crates/formats/mdl/src/semantic.rs
+++ b/crates/formats/mdl/src/semantic.rs
@@ -674,6 +674,10 @@ pub fn lower_ascii_model(model: &AsciiModel) -> ModelResult<SemanticModel> {
 }
 
 /// Lowers a compiled binary MDL model into typed semantic data.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] if lowering fails.
 pub fn lower_binary_model(model: &BinaryModel) -> ModelResult<SemanticModel> {
     let mut diagnostics = model.diagnostics.clone();
     let offset_to_name = model

--- a/crates/formats/mdl/src/semantic.rs
+++ b/crates/formats/mdl/src/semantic.rs
@@ -61,6 +61,10 @@ impl SemanticModel {
     }
 
     /// Reads and lowers a semantic model from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or lowered.
     pub fn from_file(path: impl AsRef<Path>) -> ModelResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_semantic_model(&mut file)

--- a/crates/formats/mdl/src/semantic.rs
+++ b/crates/formats/mdl/src/semantic.rs
@@ -85,7 +85,8 @@ impl SemanticModel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(
@@ -103,7 +104,8 @@ impl SemanticModel {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or lowering fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or lowering
+    /// fails.
     pub fn from_auto_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(

--- a/crates/formats/mdl/src/types.rs
+++ b/crates/formats/mdl/src/types.rs
@@ -69,7 +69,8 @@ impl Model {
     ///
     /// # Errors
     ///
-    /// Returns [`ModelError`] if the resource is not an MDL type or reading fails.
+    /// Returns [`ModelError`] if the resource is not an MDL type or reading
+    /// fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(

--- a/crates/formats/mdl/src/types.rs
+++ b/crates/formats/mdl/src/types.rs
@@ -41,6 +41,10 @@ impl Model {
     }
 
     /// Returns the model as UTF-8 text when valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Utf8Error`] if the payload is not valid UTF-8.
     pub fn as_text(&self) -> Result<&str, Utf8Error> {
         std::str::from_utf8(&self.bytes)
     }
@@ -52,12 +56,20 @@ impl Model {
     }
 
     /// Reads an `MDL` payload from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the file cannot be opened or read.
     pub fn from_file(path: impl AsRef<std::path::Path>) -> ModelResult<Self> {
         let mut file = std::fs::File::open(path.as_ref())?;
         crate::read_model(&mut file)
     }
 
     /// Reads an `MDL` payload from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError`] if the resource is not an MDL type or reading fails.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> ModelResult<Self> {
         if res.resref().res_type() != MODEL_RES_TYPE {
             return Err(ModelError::msg(format!(

--- a/crates/formats/mtr/src/lib.rs
+++ b/crates/formats/mtr/src/lib.rs
@@ -94,12 +94,20 @@ impl MtrMaterial {
     }
 
     /// Reads a typed MTR material from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MtrError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> MtrResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_mtr(&mut file)
     }
 
     /// Reads a typed MTR material from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MtrError`] if the resource is not an MTR type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> MtrResult<Self> {
         if res.resref().res_type() != MTR_RES_TYPE {
             return Err(MtrError::msg(format!(
@@ -116,6 +124,10 @@ impl MtrMaterial {
 }
 
 /// Reads a typed MTR material from `reader`.
+///
+/// # Errors
+///
+/// Returns [`MtrError`] if the data cannot be read or parsed.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_mtr<R: Read>(reader: &mut R) -> MtrResult<MtrMaterial> {
     let mut text = String::new();
@@ -192,6 +204,10 @@ pub fn parse_mtr(text: &str) -> MtrResult<MtrMaterial> {
 }
 
 /// Writes a typed MTR material to `writer`.
+///
+/// # Errors
+///
+/// Returns [`MtrError`] if the write fails.
 #[instrument(level = "debug", skip_all, err)]
 pub fn write_mtr<W: Write>(writer: &mut W, material: &MtrMaterial) -> MtrResult<()> {
     if let Some(shader) = &material.custom_shader_vs {

--- a/crates/formats/mtr/src/lib.rs
+++ b/crates/formats/mtr/src/lib.rs
@@ -107,7 +107,8 @@ impl MtrMaterial {
     ///
     /// # Errors
     ///
-    /// Returns [`MtrError`] if the resource is not an MTR type or the bytes cannot be parsed.
+    /// Returns [`MtrError`] if the resource is not an MTR type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> MtrResult<Self> {
         if res.resref().res_type() != MTR_RES_TYPE {
             return Err(MtrError::msg(format!(

--- a/crates/formats/mtr/src/lib.rs
+++ b/crates/formats/mtr/src/lib.rs
@@ -136,6 +136,10 @@ pub fn read_mtr<R: Read>(reader: &mut R) -> MtrResult<MtrMaterial> {
 }
 
 /// Parses a typed MTR material from ASCII text.
+///
+/// # Errors
+///
+/// Returns [`MtrError`] if parsing fails.
 pub fn parse_mtr(text: &str) -> MtrResult<MtrMaterial> {
     let mut material = MtrMaterial {
         render_hint:      None,

--- a/crates/formats/nwsync/src/io.rs
+++ b/crates/formats/nwsync/src/io.rs
@@ -45,7 +45,7 @@ pub fn path_for_entry(
 /// # Errors
 ///
 /// Returns [`ManifestError`] if the data cannot be read or does not conform to
-/// the NWSync manifest format.
+/// the `NWSync` manifest format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_manifest<R: Read>(reader: &mut R) -> ManifestResult<Manifest> {
     let magic = read_fixed_string(reader, 4)?;

--- a/crates/formats/nwsync/src/io.rs
+++ b/crates/formats/nwsync/src/io.rs
@@ -41,6 +41,10 @@ pub fn path_for_entry(
 }
 
 /// Reads a manifest from a stream.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] if the data cannot be read or does not conform to the NWSync manifest format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_manifest<R: Read>(reader: &mut R) -> ManifestResult<Manifest> {
     let magic = read_fixed_string(reader, 4)?;
@@ -127,6 +131,10 @@ pub fn read_manifest<R: Read>(reader: &mut R) -> ManifestResult<Manifest> {
 }
 
 /// Reads a manifest file from disk.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] if the file cannot be opened or parsed as a valid manifest.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_manifest_file(path: impl AsRef<Path>) -> ManifestResult<Manifest> {
     let file = File::open(path.as_ref())?;
@@ -135,6 +143,10 @@ pub fn read_manifest_file(path: impl AsRef<Path>) -> ManifestResult<Manifest> {
 }
 
 /// Writes a manifest to a stream.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] if the manifest is invalid or the write fails.
 #[instrument(
     level = "debug",
     skip_all,
@@ -226,6 +238,10 @@ fn compare_manifest_entries(
 }
 
 /// Writes a manifest file to disk.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] if the file cannot be created or the manifest cannot be written.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn write_manifest_file(path: impl AsRef<Path>, manifest: &Manifest) -> ManifestResult<()> {
     let file = File::create(path.as_ref())?;

--- a/crates/formats/nwsync/src/io.rs
+++ b/crates/formats/nwsync/src/io.rs
@@ -44,7 +44,8 @@ pub fn path_for_entry(
 ///
 /// # Errors
 ///
-/// Returns [`ManifestError`] if the data cannot be read or does not conform to the NWSync manifest format.
+/// Returns [`ManifestError`] if the data cannot be read or does not conform to
+/// the NWSync manifest format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_manifest<R: Read>(reader: &mut R) -> ManifestResult<Manifest> {
     let magic = read_fixed_string(reader, 4)?;
@@ -134,7 +135,8 @@ pub fn read_manifest<R: Read>(reader: &mut R) -> ManifestResult<Manifest> {
 ///
 /// # Errors
 ///
-/// Returns [`ManifestError`] if the file cannot be opened or parsed as a valid manifest.
+/// Returns [`ManifestError`] if the file cannot be opened or parsed as a valid
+/// manifest.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_manifest_file(path: impl AsRef<Path>) -> ManifestResult<Manifest> {
     let file = File::open(path.as_ref())?;
@@ -241,7 +243,8 @@ fn compare_manifest_entries(
 ///
 /// # Errors
 ///
-/// Returns [`ManifestError`] if the file cannot be created or the manifest cannot be written.
+/// Returns [`ManifestError`] if the file cannot be created or the manifest
+/// cannot be written.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn write_manifest_file(path: impl AsRef<Path>, manifest: &Manifest) -> ManifestResult<()> {
     let file = File::create(path.as_ref())?;

--- a/crates/formats/nwsync/src/types.rs
+++ b/crates/formats/nwsync/src/types.rs
@@ -153,6 +153,10 @@ impl Manifest {
     }
 
     /// Returns the configured hash tree depth.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] if the manifest version is not supported.
     pub fn hash_tree_depth(&self) -> ManifestResult<usize> {
         match self.version {
             VERSION => Ok(self.hash_tree_depth as usize),
@@ -162,6 +166,10 @@ impl Manifest {
     }
 
     /// Returns the manifest hashing algorithm label.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ManifestError`] if the manifest version is not supported.
     pub fn algorithm(&self) -> ManifestResult<&'static str> {
         if self.version == VERSION {
             Ok("SHA1")

--- a/crates/formats/plt/src/lib.rs
+++ b/crates/formats/plt/src/lib.rs
@@ -271,7 +271,8 @@ impl PltTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`PltError`] if the pixel buffer does not match the declared dimensions.
+    /// Returns [`PltError`] if the pixel buffer does not match the declared
+    /// dimensions.
     pub fn render_rgba8(&self, spec: &PltRenderSpec) -> PltResult<Vec<u8>> {
         let expected_pixels = self.pixel_count()?;
         if self.pixels.len() != expected_pixels {
@@ -310,7 +311,8 @@ impl PltTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`PltError`] if the resource is not a PLT type or the bytes cannot be parsed.
+    /// Returns [`PltError`] if the resource is not a PLT type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> PltResult<Self> {
         if res.resref().res_type() != PLT_RES_TYPE {
             return Err(PltError::msg(format!(
@@ -328,7 +330,8 @@ impl PltTexture {
 ///
 /// # Errors
 ///
-/// Returns [`PltError`] if the data cannot be read or does not conform to the PLT format.
+/// Returns [`PltError`] if the data cannot be read or does not conform to the
+/// PLT format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_plt<R: Read>(reader: &mut R) -> PltResult<PltTexture> {
     let mut bytes = Vec::new();

--- a/crates/formats/plt/src/lib.rs
+++ b/crates/formats/plt/src/lib.rs
@@ -216,6 +216,10 @@ pub struct PltTexture {
 
 impl PltTexture {
     /// Returns the total number of pixels declared by the image dimensions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the pixel count overflows `usize`.
     pub fn pixel_count(&self) -> PltResult<usize> {
         usize::try_from(self.width)
             .ok()
@@ -228,6 +232,10 @@ impl PltTexture {
     }
 
     /// Returns the pixel entry at `(x, y)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the coordinates are out of bounds.
     pub fn pixel_at(&self, x: u32, y: u32) -> PltResult<PltPixel> {
         if x >= self.width || y >= self.height {
             return Err(PltError::msg(format!(
@@ -251,11 +259,19 @@ impl PltTexture {
     }
 
     /// Parses a typed PLT texture directly from raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the bytes do not conform to the PLT format.
     pub fn read_from_texture_bytes(bytes: &[u8]) -> PltResult<Self> {
         parse_plt_bytes(bytes)
     }
 
     /// Renders the PLT into RGBA8 pixels using the provided render spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the pixel buffer does not match the declared dimensions.
     pub fn render_rgba8(&self, spec: &PltRenderSpec) -> PltResult<Vec<u8>> {
         let expected_pixels = self.pixel_count()?;
         if self.pixels.len() != expected_pixels {
@@ -281,12 +297,20 @@ impl PltTexture {
     }
 
     /// Reads a typed PLT texture from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> PltResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_plt(&mut file)
     }
 
     /// Reads a typed PLT texture from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PltError`] if the resource is not a PLT type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> PltResult<Self> {
         if res.resref().res_type() != PLT_RES_TYPE {
             return Err(PltError::msg(format!(
@@ -301,6 +325,10 @@ impl PltTexture {
 }
 
 /// Reads a typed PLT texture from `reader`.
+///
+/// # Errors
+///
+/// Returns [`PltError`] if the data cannot be read or does not conform to the PLT format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_plt<R: Read>(reader: &mut R) -> PltResult<PltTexture> {
     let mut bytes = Vec::new();
@@ -309,6 +337,10 @@ pub fn read_plt<R: Read>(reader: &mut R) -> PltResult<PltTexture> {
 }
 
 /// Writes a typed PLT texture to `writer`.
+///
+/// # Errors
+///
+/// Returns [`PltError`] if the PLT data is invalid or the write fails.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/formats/set/src/lib.rs
+++ b/crates/formats/set/src/lib.rs
@@ -90,12 +90,20 @@ pub struct SetFile {
 
 impl SetFile {
     /// Reads a typed `SET` file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> SetResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_set(&mut file)
     }
 
     /// Reads a typed `SET` file from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetError`] if the resource is not a SET type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> SetResult<Self> {
         if res.resref().res_type() != SET_RES_TYPE {
             return Err(SetError::msg(format!(
@@ -315,6 +323,10 @@ pub struct SetPrimaryRule {
 }
 
 /// Reads a typed `SET` file from `reader`.
+///
+/// # Errors
+///
+/// Returns [`SetError`] if the data cannot be read or does not conform to the SET format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_set<R: Read>(reader: &mut R) -> SetResult<SetFile> {
     let mut text = String::new();
@@ -323,6 +335,10 @@ pub fn read_set<R: Read>(reader: &mut R) -> SetResult<SetFile> {
 }
 
 /// Parses a typed `SET` file from text.
+///
+/// # Errors
+///
+/// Returns [`SetError`] if the text contains no tile definitions.
 pub fn parse_set(text: &str) -> SetResult<SetFile> {
     let mut builder = SetFile::default();
     let mut current_section = String::new();
@@ -368,6 +384,10 @@ pub fn parse_set(text: &str) -> SetResult<SetFile> {
 /// grass blocks first, followed by synthesized catalog count sections and then
 /// the indexed terrain, crosser, rule, tile, tile-door, and group sections in
 /// ascending key order.
+///
+/// # Errors
+///
+/// Returns [`SetError`] if the file contains no tile definitions.
 pub fn build_set_text(set_file: &SetFile) -> SetResult<String> {
     if set_file.tiles.is_empty() {
         return Err(SetError::msg(
@@ -426,6 +446,10 @@ pub fn build_set_text(set_file: &SetFile) -> SetResult<String> {
 }
 
 /// Writes deterministic `SET` text to `writer`.
+///
+/// # Errors
+///
+/// Returns [`SetError`] if the file contains no tile definitions or the write fails.
 pub fn write_set<W: Write>(writer: &mut W, set_file: &SetFile) -> SetResult<()> {
     let text = build_set_text(set_file)?;
     writer.write_all(text.as_bytes())?;

--- a/crates/formats/set/src/lib.rs
+++ b/crates/formats/set/src/lib.rs
@@ -103,7 +103,8 @@ impl SetFile {
     ///
     /// # Errors
     ///
-    /// Returns [`SetError`] if the resource is not a SET type or the bytes cannot be parsed.
+    /// Returns [`SetError`] if the resource is not a SET type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> SetResult<Self> {
         if res.resref().res_type() != SET_RES_TYPE {
             return Err(SetError::msg(format!(
@@ -326,7 +327,8 @@ pub struct SetPrimaryRule {
 ///
 /// # Errors
 ///
-/// Returns [`SetError`] if the data cannot be read or does not conform to the SET format.
+/// Returns [`SetError`] if the data cannot be read or does not conform to the
+/// SET format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_set<R: Read>(reader: &mut R) -> SetResult<SetFile> {
     let mut text = String::new();
@@ -449,7 +451,8 @@ pub fn build_set_text(set_file: &SetFile) -> SetResult<String> {
 ///
 /// # Errors
 ///
-/// Returns [`SetError`] if the file contains no tile definitions or the write fails.
+/// Returns [`SetError`] if the file contains no tile definitions or the write
+/// fails.
 pub fn write_set<W: Write>(writer: &mut W, set_file: &SetFile) -> SetResult<()> {
     let text = build_set_text(set_file)?;
     writer.write_all(text.as_bytes())?;

--- a/crates/formats/ssf/src/io.rs
+++ b/crates/formats/ssf/src/io.rs
@@ -11,7 +11,8 @@ use crate::{
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the data cannot be read or does not conform to the SSF format.
+/// Returns an [`io::Error`] if the data cannot be read or does not conform to
+/// the SSF format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_ssf<R: Read + Seek>(reader: &mut R) -> SsfResult<SsfRoot> {
     let file_type = read_str_or_err(reader, 4)?;
@@ -73,7 +74,8 @@ pub fn read_ssf<R: Read + Seek>(reader: &mut R) -> SsfResult<SsfRoot> {
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the SSF data cannot be serialized or the write fails.
+/// Returns an [`io::Error`] if the SSF data cannot be serialized or the write
+/// fails.
 #[instrument(level = "debug", skip_all, err, fields(entry_count = ssf.entries.len()))]
 pub fn write_ssf<W: Write>(writer: &mut W, ssf: &SsfRoot) -> SsfResult<()> {
     writer.write_all(HEADER_MAGIC.as_bytes())?;

--- a/crates/formats/ssf/src/io.rs
+++ b/crates/formats/ssf/src/io.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 
 /// Reads an `SSF` document from `reader`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the data cannot be read or does not conform to the SSF format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_ssf<R: Read + Seek>(reader: &mut R) -> SsfResult<SsfRoot> {
     let file_type = read_str_or_err(reader, 4)?;
@@ -66,6 +70,10 @@ pub fn read_ssf<R: Read + Seek>(reader: &mut R) -> SsfResult<SsfRoot> {
 }
 
 /// Writes an `SSF` document to `writer`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the SSF data cannot be serialized or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(entry_count = ssf.entries.len()))]
 pub fn write_ssf<W: Write>(writer: &mut W, ssf: &SsfRoot) -> SsfResult<()> {
     writer.write_all(HEADER_MAGIC.as_bytes())?;

--- a/crates/formats/tga/src/lib.rs
+++ b/crates/formats/tga/src/lib.rs
@@ -166,6 +166,10 @@ pub struct TgaTexture {
 
 impl TgaTexture {
     /// Encodes top-left-origin RGBA8 pixels into an uncompressed 32-bit TGA.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if `rgba` does not match the expected length for the given dimensions.
     pub fn encode_rgba8(width: u16, height: u16, rgba: &[u8]) -> TgaResult<Self> {
         let expected_len = rgba_len(width, height)?;
         if rgba.len() != expected_len {
@@ -204,6 +208,10 @@ impl TgaTexture {
     }
 
     /// Returns the total number of pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if the pixel count overflows `usize`.
     pub fn pixel_count(&self) -> TgaResult<usize> {
         usize::from(self.width)
             .checked_mul(usize::from(self.height))
@@ -229,6 +237,10 @@ impl TgaTexture {
     }
 
     /// Returns the stored image payload expanded into raw pixel bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if the pixel depth is unsupported or the image data is malformed.
     pub fn expanded_image_data(&self) -> TgaResult<Vec<u8>> {
         let bytes_per_pixel = pixel_size_bytes(self.pixel_depth)?;
         let pixel_count = self.pixel_count()?;
@@ -249,6 +261,10 @@ impl TgaTexture {
     }
 
     /// Decodes the TGA image into top-left-origin RGBA8 pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if the image type is unsupported or the pixel data is malformed.
     #[allow(clippy::many_single_char_names)]
     pub fn decode_rgba8(&self) -> TgaResult<Vec<u8>> {
         if self.image_type.uses_color_map() {
@@ -305,12 +321,20 @@ impl TgaTexture {
     }
 
     /// Reads a typed TGA texture from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> TgaResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_tga(&mut file)
     }
 
     /// Reads a typed TGA texture from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TgaError`] if the resource is not a TGA type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TgaResult<Self> {
         if res.resref().res_type() != TGA_RES_TYPE {
             return Err(TgaError::msg(format!(
@@ -325,6 +349,10 @@ impl TgaTexture {
 }
 
 /// Reads a typed TGA texture from `reader`.
+///
+/// # Errors
+///
+/// Returns [`TgaError`] if the data cannot be read or does not conform to the TGA format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_tga<R: Read>(reader: &mut R) -> TgaResult<TgaTexture> {
     let mut bytes = Vec::new();
@@ -333,6 +361,10 @@ pub fn read_tga<R: Read>(reader: &mut R) -> TgaResult<TgaTexture> {
 }
 
 /// Writes a typed TGA texture to `writer`.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] if the write fails.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/formats/tga/src/lib.rs
+++ b/crates/formats/tga/src/lib.rs
@@ -169,7 +169,8 @@ impl TgaTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`TgaError`] if `rgba` does not match the expected length for the given dimensions.
+    /// Returns [`TgaError`] if `rgba` does not match the expected length for
+    /// the given dimensions.
     pub fn encode_rgba8(width: u16, height: u16, rgba: &[u8]) -> TgaResult<Self> {
         let expected_len = rgba_len(width, height)?;
         if rgba.len() != expected_len {
@@ -240,7 +241,8 @@ impl TgaTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`TgaError`] if the pixel depth is unsupported or the image data is malformed.
+    /// Returns [`TgaError`] if the pixel depth is unsupported or the image data
+    /// is malformed.
     pub fn expanded_image_data(&self) -> TgaResult<Vec<u8>> {
         let bytes_per_pixel = pixel_size_bytes(self.pixel_depth)?;
         let pixel_count = self.pixel_count()?;
@@ -264,7 +266,8 @@ impl TgaTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`TgaError`] if the image type is unsupported or the pixel data is malformed.
+    /// Returns [`TgaError`] if the image type is unsupported or the pixel data
+    /// is malformed.
     #[allow(clippy::many_single_char_names)]
     pub fn decode_rgba8(&self) -> TgaResult<Vec<u8>> {
         if self.image_type.uses_color_map() {
@@ -334,7 +337,8 @@ impl TgaTexture {
     ///
     /// # Errors
     ///
-    /// Returns [`TgaError`] if the resource is not a TGA type or the bytes cannot be parsed.
+    /// Returns [`TgaError`] if the resource is not a TGA type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TgaResult<Self> {
         if res.resref().res_type() != TGA_RES_TYPE {
             return Err(TgaError::msg(format!(
@@ -352,7 +356,8 @@ impl TgaTexture {
 ///
 /// # Errors
 ///
-/// Returns [`TgaError`] if the data cannot be read or does not conform to the TGA format.
+/// Returns [`TgaError`] if the data cannot be read or does not conform to the
+/// TGA format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_tga<R: Read>(reader: &mut R) -> TgaResult<TgaTexture> {
     let mut bytes = Vec::new();

--- a/crates/formats/tlk/src/io.rs
+++ b/crates/formats/tlk/src/io.rs
@@ -30,7 +30,8 @@ pub struct TlkLayerWriteTarget<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`TlkError`] if the data cannot be read or does not conform to the TLK format.
+/// Returns [`TlkError`] if the data cannot be read or does not conform to the
+/// TLK format.
 #[instrument(level = "debug", skip_all, err, fields(cache_policy = ?cache_policy))]
 pub fn read_single_tlk<R>(mut reader: R, cache_policy: CachePolicy) -> TlkResult<SingleTlk>
 where
@@ -168,7 +169,8 @@ pub fn write_single_tlk<W: Write + Seek>(writer: &mut W, tlk: &mut SingleTlk) ->
 ///
 /// # Errors
 ///
-/// Returns [`TlkError`] if the number of targets does not match the chain length or any write fails.
+/// Returns [`TlkError`] if the number of targets does not match the chain
+/// length or any write fails.
 #[instrument(level = "debug", skip_all, err, fields(layer_count = tlk.chain.len()))]
 pub fn write_tlk_chain(targets: &mut [TlkLayerWriteTarget<'_>], tlk: &mut Tlk) -> TlkResult<()> {
     if targets.len() != tlk.chain.len() {

--- a/crates/formats/tlk/src/io.rs
+++ b/crates/formats/tlk/src/io.rs
@@ -27,6 +27,10 @@ pub struct TlkLayerWriteTarget<'a> {
 }
 
 /// Reads a single-language TLK table from a reader.
+///
+/// # Errors
+///
+/// Returns [`TlkError`] if the data cannot be read or does not conform to the TLK format.
 #[instrument(level = "debug", skip_all, err, fields(cache_policy = ?cache_policy))]
 pub fn read_single_tlk<R>(mut reader: R, cache_policy: CachePolicy) -> TlkResult<SingleTlk>
 where
@@ -73,6 +77,10 @@ where
 ///
 /// Missing string references up to [`SingleTlk::highest`] are emitted as empty
 /// entries.
+///
+/// # Errors
+///
+/// Returns [`TlkError`] if the TLK data is invalid or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(language = ?tlk.language))]
 pub fn write_single_tlk<W: Write + Seek>(writer: &mut W, tlk: &mut SingleTlk) -> TlkResult<()> {
     if tlk.static_entries.is_empty()
@@ -157,6 +165,10 @@ pub fn write_single_tlk<W: Write + Seek>(writer: &mut W, tlk: &mut SingleTlk) ->
 }
 
 /// Writes a layered TLK chain to explicit male/female layer targets.
+///
+/// # Errors
+///
+/// Returns [`TlkError`] if the number of targets does not match the chain length or any write fails.
 #[instrument(level = "debug", skip_all, err, fields(layer_count = tlk.chain.len()))]
 pub fn write_tlk_chain(targets: &mut [TlkLayerWriteTarget<'_>], tlk: &mut Tlk) -> TlkResult<()> {
     if targets.len() != tlk.chain.len() {

--- a/crates/formats/tlk/src/types.rs
+++ b/crates/formats/tlk/src/types.rs
@@ -317,7 +317,8 @@ impl SingleTlk {
     ///
     /// # Errors
     ///
-    /// Returns [`TlkError`] if the resource bytes cannot be parsed as a TLK table.
+    /// Returns [`TlkError`] if the resource bytes cannot be parsed as a TLK
+    /// table.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TlkResult<Self> {
         let bytes = res.read_all(cache_policy)?;
         crate::io::read_single_tlk(Cursor::new(bytes), cache_policy)

--- a/crates/formats/tlk/src/types.rs
+++ b/crates/formats/tlk/src/types.rs
@@ -304,12 +304,20 @@ impl SingleTlk {
     }
 
     /// Opens a TLK file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlkError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>, cache_policy: CachePolicy) -> TlkResult<Self> {
         let file = File::open(path.as_ref())?;
         crate::io::read_single_tlk(file, cache_policy)
     }
 
     /// Reads a TLK payload from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlkError`] if the resource bytes cannot be parsed as a TLK table.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TlkResult<Self> {
         let bytes = res.read_all(cache_policy)?;
         crate::io::read_single_tlk(Cursor::new(bytes), cache_policy)
@@ -323,6 +331,10 @@ impl SingleTlk {
     }
 
     /// Returns the entry for `str_ref`, if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlkError`] if the underlying IO read fails.
     pub fn get(&mut self, str_ref: StrRef) -> TlkResult<Option<TlkEntry>> {
         if let Some(entry) = self.static_entries.get(&str_ref) {
             return Ok(Some(entry.clone()));
@@ -420,6 +432,10 @@ impl Tlk {
     }
 
     /// Queries the chain for `str_ref` using the requested gender.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlkError`] if the underlying IO read fails.
     pub fn get(&mut self, str_ref: StrRef, gender: Gender) -> TlkResult<Option<TlkEntry>> {
         for pair in &mut self.chain {
             let queried = match gender {

--- a/crates/formats/tlk/src/types.rs
+++ b/crates/formats/tlk/src/types.rs
@@ -412,6 +412,10 @@ impl Tlk {
     }
 
     /// Builds a TLK chain from resource pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlkError`] if any resource pair cannot be read or parsed.
     pub fn from_res_pairs(
         chain: &[(Option<Res>, Option<Res>)],
         cache_policy: CachePolicy,

--- a/crates/formats/twoda/src/io.rs
+++ b/crates/formats/twoda/src/io.rs
@@ -10,6 +10,10 @@ use crate::{
 };
 
 /// Reads a `2DA V2.0` table from text.
+///
+/// # Errors
+///
+/// Returns [`TwoDaError`] if the data cannot be read or does not conform to the 2DA V2.0 format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_twoda<R: Read>(mut reader: R) -> TwoDaResult<TwoDa> {
     let mut bytes = Vec::new();
@@ -133,6 +137,10 @@ pub fn read_twoda<R: Read>(mut reader: R) -> TwoDaResult<TwoDa> {
 ///
 /// When `minify` is `true`, column padding is reduced to the minimum required
 /// whitespace.
+///
+/// # Errors
+///
+/// Returns [`TwoDaError`] if the table has no columns or a cell value cannot be escaped.
 #[instrument(
     level = "debug",
     skip_all,
@@ -255,12 +263,20 @@ pub fn write_twoda<W: Write>(writer: &mut W, twoda: &TwoDa, minify: bool) -> Two
 }
 
 /// Reads a `2DA V2.0` table from a [`Res`].
+///
+/// # Errors
+///
+/// Returns [`TwoDaError`] if the resource bytes cannot be parsed as a 2DA table.
 #[instrument(level = "debug", skip_all, err)]
 pub fn as_2da(res: &Res) -> TwoDaResult<TwoDa> {
     read_twoda(std::io::Cursor::new(res.read_all(CachePolicy::Bypass)?))
 }
 
 /// Formats a cell for textual 2DA output.
+///
+/// # Errors
+///
+/// Returns [`TwoDaError`] if the cell value contains double-quote characters.
 pub fn escape_field(field: &Cell) -> TwoDaResult<String> {
     match field {
         None => Ok("****".to_string()),

--- a/crates/formats/twoda/src/io.rs
+++ b/crates/formats/twoda/src/io.rs
@@ -13,7 +13,8 @@ use crate::{
 ///
 /// # Errors
 ///
-/// Returns [`TwoDaError`] if the data cannot be read or does not conform to the 2DA V2.0 format.
+/// Returns [`TwoDaError`] if the data cannot be read or does not conform to the
+/// 2DA V2.0 format.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_twoda<R: Read>(mut reader: R) -> TwoDaResult<TwoDa> {
     let mut bytes = Vec::new();
@@ -140,7 +141,8 @@ pub fn read_twoda<R: Read>(mut reader: R) -> TwoDaResult<TwoDa> {
 ///
 /// # Errors
 ///
-/// Returns [`TwoDaError`] if the table has no columns or a cell value cannot be escaped.
+/// Returns [`TwoDaError`] if the table has no columns or a cell value cannot be
+/// escaped.
 #[instrument(
     level = "debug",
     skip_all,
@@ -266,7 +268,8 @@ pub fn write_twoda<W: Write>(writer: &mut W, twoda: &TwoDa, minify: bool) -> Two
 ///
 /// # Errors
 ///
-/// Returns [`TwoDaError`] if the resource bytes cannot be parsed as a 2DA table.
+/// Returns [`TwoDaError`] if the resource bytes cannot be parsed as a 2DA
+/// table.
 #[instrument(level = "debug", skip_all, err)]
 pub fn as_2da(res: &Res) -> TwoDaResult<TwoDa> {
     read_twoda(std::io::Cursor::new(res.read_all(CachePolicy::Bypass)?))

--- a/crates/formats/twoda/src/types.rs
+++ b/crates/formats/twoda/src/types.rs
@@ -209,7 +209,8 @@ impl TwoDa {
     ///
     /// # Errors
     ///
-    /// Returns [`TwoDaError`] if `row` is out of bounds or `column` does not exist.
+    /// Returns [`TwoDaError`] if `row` is out of bounds or `column` does not
+    /// exist.
     pub fn set_cell(&mut self, row: usize, column: &str, value: Cell) -> TwoDaResult<()> {
         if row >= self.rows.len() {
             return Err(TwoDaError::msg("Row out of bounds"));
@@ -295,7 +296,8 @@ impl TwoDa {
     ///
     /// # Errors
     ///
-    /// Returns [`TwoDaError`] if `rows` and `row_labels` have different lengths.
+    /// Returns [`TwoDaError`] if `rows` and `row_labels` have different
+    /// lengths.
     pub fn replace_rows(&mut self, rows: Vec<Row>, row_labels: Vec<String>) -> TwoDaResult<()> {
         if rows.len() != row_labels.len() {
             return Err(TwoDaError::msg("row data and row labels length mismatch"));

--- a/crates/formats/twoda/src/types.rs
+++ b/crates/formats/twoda/src/types.rs
@@ -206,6 +206,10 @@ impl TwoDa {
     }
 
     /// Sets the cell at `row` and `column`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TwoDaError`] if `row` is out of bounds or `column` does not exist.
     pub fn set_cell(&mut self, row: usize, column: &str, value: Cell) -> TwoDaResult<()> {
         if row >= self.rows.len() {
             return Err(TwoDaError::msg("Row out of bounds"));
@@ -274,6 +278,10 @@ impl TwoDa {
     }
 
     /// Replaces the stored row label.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TwoDaError`] if `row` is out of bounds.
     pub fn set_row_label(&mut self, row: usize, label: impl Into<String>) -> TwoDaResult<()> {
         let slot = self
             .row_labels
@@ -284,6 +292,10 @@ impl TwoDa {
     }
 
     /// Replaces all rows and row labels at once.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TwoDaError`] if `rows` and `row_labels` have different lengths.
     pub fn replace_rows(&mut self, rows: Vec<Row>, row_labels: Vec<String>) -> TwoDaResult<()> {
         if rows.len() != row_labels.len() {
             return Err(TwoDaError::msg("row data and row labels length mismatch"));
@@ -302,6 +314,10 @@ impl TwoDa {
     /// Replaces the column list.
     ///
     /// Column lookups are case-insensitive.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TwoDaError`] if any column name is blank.
     pub fn set_columns(&mut self, columns: Vec<String>) -> TwoDaResult<()> {
         for column in &columns {
             if column.trim().is_empty() {

--- a/crates/formats/txi/src/lib.rs
+++ b/crates/formats/txi/src/lib.rs
@@ -123,7 +123,8 @@ impl TxiFile {
     ///
     /// # Errors
     ///
-    /// Returns [`TxiError`] if the resource is not a TXI type or the bytes cannot be parsed.
+    /// Returns [`TxiError`] if the resource is not a TXI type or the bytes
+    /// cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TxiResult<Self> {
         if res.resref().res_type() != TXI_RES_TYPE {
             return Err(TxiError::msg(format!(
@@ -141,7 +142,8 @@ impl TxiFile {
     ///
     /// # Errors
     ///
-    /// Returns [`TxiError`] if the resref is invalid, the resource is not found, or parsing fails.
+    /// Returns [`TxiError`] if the resref is invalid, the resource is not
+    /// found, or parsing fails.
     pub fn from_resman(
         resman: &mut ResMan,
         name: &str,
@@ -285,7 +287,8 @@ pub fn parse_txi(text: &str) -> TxiResult<TxiFile> {
 ///
 /// # Errors
 ///
-/// This function currently always succeeds but returns [`TxiResult`] for forward compatibility.
+/// This function currently always succeeds but returns [`TxiResult`] for
+/// forward compatibility.
 pub fn build_txi_text(txi_file: &TxiFile) -> TxiResult<String> {
     let directives = if txi_file.directives.is_empty() {
         synthesize_directives(txi_file)

--- a/crates/formats/txi/src/lib.rs
+++ b/crates/formats/txi/src/lib.rs
@@ -110,12 +110,20 @@ impl TxiFile {
     }
 
     /// Reads a typed `TXI` payload from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxiError`] if the file cannot be opened or parsed.
     pub fn from_file(path: impl AsRef<Path>) -> TxiResult<Self> {
         let mut file = File::open(path.as_ref())?;
         read_txi(&mut file)
     }
 
     /// Reads a typed `TXI` payload from a [`Res`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxiError`] if the resource is not a TXI type or the bytes cannot be parsed.
     pub fn from_res(res: &Res, cache_policy: CachePolicy) -> TxiResult<Self> {
         if res.resref().res_type() != TXI_RES_TYPE {
             return Err(TxiError::msg(format!(
@@ -130,6 +138,10 @@ impl TxiFile {
     }
 
     /// Reads a typed `TXI` payload from a [`ResMan`] by texture name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxiError`] if the resref is invalid, the resource is not found, or parsing fails.
     pub fn from_resman(
         resman: &mut ResMan,
         name: &str,
@@ -144,6 +156,10 @@ impl TxiFile {
     }
 
     /// Reads an optional typed `TXI` payload from a [`ResMan`] by texture name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxiError`] if the resref is invalid or parsing fails.
     pub fn optional_from_resman(
         resman: &mut ResMan,
         name: &str,
@@ -192,6 +208,10 @@ impl TxiDirective {
 }
 
 /// Reads a typed `TXI` payload from any reader.
+///
+/// # Errors
+///
+/// Returns [`TxiError`] if the data cannot be read or parsed.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_txi(reader: &mut dyn Read) -> TxiResult<TxiFile> {
     let mut text = String::new();
@@ -200,6 +220,10 @@ pub fn read_txi(reader: &mut dyn Read) -> TxiResult<TxiFile> {
 }
 
 /// Parses a typed `TXI` payload from text.
+///
+/// # Errors
+///
+/// Returns [`TxiError`] if a continuation line appears before any directive.
 pub fn parse_txi(text: &str) -> TxiResult<TxiFile> {
     let mut directives = Vec::new();
     for (line_index, line) in text.lines().enumerate() {
@@ -258,6 +282,10 @@ pub fn parse_txi(text: &str) -> TxiResult<TxiFile> {
 /// directly in preserved order. When no directives are present, the serializer
 /// synthesizes a directive stream from the recognized typed fields in a stable
 /// order.
+///
+/// # Errors
+///
+/// This function currently always succeeds but returns [`TxiResult`] for forward compatibility.
 pub fn build_txi_text(txi_file: &TxiFile) -> TxiResult<String> {
     let directives = if txi_file.directives.is_empty() {
         synthesize_directives(txi_file)
@@ -286,6 +314,10 @@ pub fn build_txi_text(txi_file: &TxiFile) -> TxiResult<String> {
 }
 
 /// Writes deterministic `TXI` text to `writer`.
+///
+/// # Errors
+///
+/// Returns [`TxiError`] if the write fails.
 pub fn write_txi<W: Write>(writer: &mut W, txi_file: &TxiFile) -> TxiResult<()> {
     let text = build_txi_text(txi_file)?;
     writer.write_all(text.as_bytes())?;

--- a/crates/foundation/checksums/src/digest.rs
+++ b/crates/foundation/checksums/src/digest.rs
@@ -13,6 +13,10 @@ pub fn secure_hash(data: impl AsRef<[u8]>) -> SecureHash {
 }
 
 /// Parses a lowercase or uppercase hexadecimal SHA-1 digest.
+///
+/// # Errors
+///
+/// Returns [`ParseSecureHashError`] if the input is not a valid 40-character hex SHA-1 string.
 #[instrument(level = "debug", skip_all, err, fields(input_len = input.len()))]
 pub fn parse_secure_hash(input: &str) -> Result<SecureHash, ParseSecureHashError> {
     if input.len() != SECURE_HASH_HEX_LEN {

--- a/crates/foundation/checksums/src/digest.rs
+++ b/crates/foundation/checksums/src/digest.rs
@@ -16,7 +16,8 @@ pub fn secure_hash(data: impl AsRef<[u8]>) -> SecureHash {
 ///
 /// # Errors
 ///
-/// Returns [`ParseSecureHashError`] if the input is not a valid 40-character hex SHA-1 string.
+/// Returns [`ParseSecureHashError`] if the input is not a valid 40-character
+/// hex SHA-1 string.
 #[instrument(level = "debug", skip_all, err, fields(input_len = input.len()))]
 pub fn parse_secure_hash(input: &str) -> Result<SecureHash, ParseSecureHashError> {
     if input.len() != SECURE_HASH_HEX_LEN {

--- a/crates/foundation/encoding/src/encoding.rs
+++ b/crates/foundation/encoding/src/encoding.rs
@@ -25,7 +25,8 @@ pub fn get_nwnrs_encoding_name() -> &'static str {
 ///
 /// # Errors
 ///
-/// Returns [`UnknownEncodingError`] if `label` does not map to a known encoding.
+/// Returns [`UnknownEncodingError`] if `label` does not map to a known
+/// encoding.
 #[instrument(level = "debug", skip_all, err, fields(label = %label))]
 pub fn set_nwnrs_encoding(label: &str) -> Result<(), UnknownEncodingError> {
     let encoding =
@@ -64,7 +65,8 @@ pub fn get_native_encoding_name() -> Result<&'static str, NativeEncodingError> {
 ///
 /// # Errors
 ///
-/// Returns [`UnknownEncodingError`] if `label` does not map to a known encoding.
+/// Returns [`UnknownEncodingError`] if `label` does not map to a known
+/// encoding.
 #[instrument(level = "debug", skip_all, err, fields(label = %label))]
 pub fn set_native_encoding(label: &str) -> Result<(), UnknownEncodingError> {
     let encoding =
@@ -100,7 +102,8 @@ pub fn detect_system_native_encoding() -> Result<&'static Encoding, NativeEncodi
 ///
 /// # Errors
 ///
-/// Returns [`EncodingConversionError`] if the string cannot be represented in the current NWN encoding.
+/// Returns [`EncodingConversionError`] if the string cannot be represented in
+/// the current NWN encoding.
 #[instrument(level = "debug", skip_all, err, fields(input_len = value.len()))]
 pub fn to_nwnrs_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionError> {
     encode_with(get_nwnrs_encoding(), value, "encode text for NWN")
@@ -110,7 +113,8 @@ pub fn to_nwnrs_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionError
 ///
 /// # Errors
 ///
-/// Returns [`EncodingConversionError`] if the bytes cannot be decoded with the current NWN encoding.
+/// Returns [`EncodingConversionError`] if the bytes cannot be decoded with the
+/// current NWN encoding.
 #[instrument(level = "debug", skip_all, err, fields(input_len = bytes.len()))]
 pub fn from_nwnrs_encoding(bytes: &[u8]) -> Result<String, EncodingConversionError> {
     decode_with(get_nwnrs_encoding(), bytes, "decode text from NWN")
@@ -120,7 +124,8 @@ pub fn from_nwnrs_encoding(bytes: &[u8]) -> Result<String, EncodingConversionErr
 ///
 /// # Errors
 ///
-/// Returns [`EncodingConversionError`] if the system encoding cannot be detected or the string cannot be represented in it.
+/// Returns [`EncodingConversionError`] if the system encoding cannot be
+/// detected or the string cannot be represented in it.
 #[instrument(level = "debug", skip_all, err, fields(input_len = value.len()))]
 pub fn to_native_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionError> {
     let encoding = get_native_encoding().map_err(|error| {
@@ -133,7 +138,8 @@ pub fn to_native_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionErro
 ///
 /// # Errors
 ///
-/// Returns [`EncodingConversionError`] if the system encoding cannot be detected or the bytes cannot be decoded with it.
+/// Returns [`EncodingConversionError`] if the system encoding cannot be
+/// detected or the bytes cannot be decoded with it.
 #[instrument(level = "debug", skip_all, err, fields(input_len = bytes.len()))]
 pub fn from_native_encoding(bytes: &[u8]) -> Result<String, EncodingConversionError> {
     let encoding = get_native_encoding().map_err(|error| {

--- a/crates/foundation/encoding/src/encoding.rs
+++ b/crates/foundation/encoding/src/encoding.rs
@@ -22,6 +22,10 @@ pub fn get_nwnrs_encoding_name() -> &'static str {
 }
 
 /// Sets the encoding used for NWN text data.
+///
+/// # Errors
+///
+/// Returns [`UnknownEncodingError`] if `label` does not map to a known encoding.
 #[instrument(level = "debug", skip_all, err, fields(label = %label))]
 pub fn set_nwnrs_encoding(label: &str) -> Result<(), UnknownEncodingError> {
     let encoding =
@@ -31,6 +35,10 @@ pub fn set_nwnrs_encoding(label: &str) -> Result<(), UnknownEncodingError> {
 }
 
 /// Returns the configured or detected native system encoding.
+///
+/// # Errors
+///
+/// Returns [`NativeEncodingError`] if the system encoding cannot be detected.
 #[instrument(level = "debug", err)]
 pub fn get_native_encoding() -> Result<&'static Encoding, NativeEncodingError> {
     if let Some(encoding) = NATIVE_ENCODING.with(Cell::get) {
@@ -43,12 +51,20 @@ pub fn get_native_encoding() -> Result<&'static Encoding, NativeEncodingError> {
 }
 
 /// Returns the canonical label for the native system encoding.
+///
+/// # Errors
+///
+/// Returns [`NativeEncodingError`] if the system encoding cannot be detected.
 #[instrument(level = "debug", err)]
 pub fn get_native_encoding_name() -> Result<&'static str, NativeEncodingError> {
     Ok(get_native_encoding()?.name())
 }
 
 /// Overrides the detected native system encoding.
+///
+/// # Errors
+///
+/// Returns [`UnknownEncodingError`] if `label` does not map to a known encoding.
 #[instrument(level = "debug", skip_all, err, fields(label = %label))]
 pub fn set_native_encoding(label: &str) -> Result<(), UnknownEncodingError> {
     let encoding =
@@ -63,6 +79,10 @@ pub fn clear_native_encoding() {
 }
 
 /// Detects the process-native text encoding for the current platform.
+///
+/// # Errors
+///
+/// Returns [`NativeEncodingError`] if the system encoding cannot be determined.
 #[instrument(level = "debug", err)]
 pub fn detect_system_native_encoding() -> Result<&'static Encoding, NativeEncodingError> {
     #[cfg(windows)]
@@ -77,18 +97,30 @@ pub fn detect_system_native_encoding() -> Result<&'static Encoding, NativeEncodi
 }
 
 /// Encodes a string using the current NWN encoding.
+///
+/// # Errors
+///
+/// Returns [`EncodingConversionError`] if the string cannot be represented in the current NWN encoding.
 #[instrument(level = "debug", skip_all, err, fields(input_len = value.len()))]
 pub fn to_nwnrs_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionError> {
     encode_with(get_nwnrs_encoding(), value, "encode text for NWN")
 }
 
 /// Decodes bytes using the current NWN encoding.
+///
+/// # Errors
+///
+/// Returns [`EncodingConversionError`] if the bytes cannot be decoded with the current NWN encoding.
 #[instrument(level = "debug", skip_all, err, fields(input_len = bytes.len()))]
 pub fn from_nwnrs_encoding(bytes: &[u8]) -> Result<String, EncodingConversionError> {
     decode_with(get_nwnrs_encoding(), bytes, "decode text from NWN")
 }
 
 /// Encodes a string using the current native system encoding.
+///
+/// # Errors
+///
+/// Returns [`EncodingConversionError`] if the system encoding cannot be detected or the string cannot be represented in it.
 #[instrument(level = "debug", skip_all, err, fields(input_len = value.len()))]
 pub fn to_native_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionError> {
     let encoding = get_native_encoding().map_err(|error| {
@@ -98,6 +130,10 @@ pub fn to_native_encoding(value: &str) -> Result<Vec<u8>, EncodingConversionErro
 }
 
 /// Decodes bytes using the current native system encoding.
+///
+/// # Errors
+///
+/// Returns [`EncodingConversionError`] if the system encoding cannot be detected or the bytes cannot be decoded with it.
 #[instrument(level = "debug", skip_all, err, fields(input_len = bytes.len()))]
 pub fn from_native_encoding(bytes: &[u8]) -> Result<String, EncodingConversionError> {
     let encoding = get_native_encoding().map_err(|error| {

--- a/crates/foundation/io/src/io.rs
+++ b/crates/foundation/io/src/io.rs
@@ -20,7 +20,8 @@ pub fn read_bytes_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::R
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or the bytes are not valid UTF-8.
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or
+/// the bytes are not valid UTF-8.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_str_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::Result<String> {
     let bytes = read_bytes_or_err(reader, size)?;

--- a/crates/foundation/io/src/io.rs
+++ b/crates/foundation/io/src/io.rs
@@ -5,6 +5,10 @@ use tracing::instrument;
 use crate::ExpectationError;
 
 /// Reads exactly `size` bytes or returns the underlying IO error.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_bytes_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::Result<Vec<u8>> {
     let mut bytes = vec![0_u8; size];
@@ -13,6 +17,10 @@ pub fn read_bytes_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::R
 }
 
 /// Reads exactly `size` bytes and decodes them as UTF-8.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or the bytes are not valid UTF-8.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_str_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::Result<String> {
     let bytes = read_bytes_or_err(reader, size)?;
@@ -20,6 +28,10 @@ pub fn read_str_or_err<R: Read + ?Sized>(reader: &mut R, size: usize) -> io::Res
 }
 
 /// Reads exactly `count` items, passing each zero-based index to `item_reader`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if `item_reader` fails for any item.
 #[instrument(level = "debug", skip_all, err, fields(count))]
 pub fn read_fixed_count_seq<R, T, F>(
     reader: &mut R,
@@ -39,6 +51,10 @@ where
 
 /// Returns `Ok(())` when `condition` is true, otherwise an
 /// [`ExpectationError`].
+///
+/// # Errors
+///
+/// Returns [`ExpectationError`] if `condition` is false.
 pub fn expect(condition: bool, message: impl Into<String>) -> Result<(), ExpectationError> {
     if condition {
         Ok(())

--- a/crates/foundation/localization/src/resolve.rs
+++ b/crates/foundation/localization/src/resolve.rs
@@ -3,6 +3,10 @@ use tracing::instrument;
 use crate::prelude::*;
 
 /// Resolves a language from a numeric id, short code, or English name.
+///
+/// # Errors
+///
+/// Returns [`ParseLanguageError`] if the input does not match a known language id, shortcode, or name.
 #[instrument(level = "debug", skip_all, err, fields(input = %input))]
 pub fn resolve_language(input: &str) -> Result<Language, ParseLanguageError> {
     if input.chars().all(|ch| ch.is_ascii_digit()) {

--- a/crates/foundation/localization/src/resolve.rs
+++ b/crates/foundation/localization/src/resolve.rs
@@ -6,7 +6,8 @@ use crate::prelude::*;
 ///
 /// # Errors
 ///
-/// Returns [`ParseLanguageError`] if the input does not match a known language id, shortcode, or name.
+/// Returns [`ParseLanguageError`] if the input does not match a known language
+/// id, shortcode, or name.
 #[instrument(level = "debug", skip_all, err, fields(input = %input))]
 pub fn resolve_language(input: &str) -> Result<Language, ParseLanguageError> {
     if input.chars().all(|ch| ch.is_ascii_digit()) {

--- a/crates/foundation/streamext/src/io.rs
+++ b/crates/foundation/streamext/src/io.rs
@@ -8,7 +8,8 @@ use crate::prelude::*;
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the prefix or the subsequent bytes cannot be read, or if the prefix length does not match `expect_fixed_size`.
+/// Returns an [`io::Error`] if the prefix or the subsequent bytes cannot be
+/// read, or if the prefix length does not match `expect_fixed_size`.
 #[instrument(
     level = "debug",
     skip_all,
@@ -76,7 +77,8 @@ pub fn read_bytes<R: Read>(reader: &mut R, size: usize) -> io::Result<Vec<u8>> {
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or the bytes are not valid UTF-8.
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or
+/// the bytes are not valid UTF-8.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_string<R: Read>(reader: &mut R, size: usize) -> io::Result<String> {
     let bytes = read_bytes(reader, size)?;
@@ -87,7 +89,8 @@ pub fn read_string<R: Read>(reader: &mut R, size: usize) -> io::Result<String> {
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the bytes cannot be read or do not match `value`.
+/// Returns an [`io::Error`] if the bytes cannot be read or do not match
+/// `value`.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn read_fixed_value<R: Read>(reader: &mut R, value: &[u8]) -> io::Result<()> {
     let data = read_bytes(reader, value.len())?;
@@ -146,7 +149,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the length does not fit the prefix type or the write fails.
+/// Returns an [`io::Error`] if the length does not fit the prefix type or the
+/// write fails.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn write_size_prefixed_bytes<P, W>(writer: &mut W, value: &[u8]) -> io::Result<()>
 where
@@ -167,7 +171,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the byte length does not fit the prefix type or the write fails.
+/// Returns an [`io::Error`] if the byte length does not fit the prefix type or
+/// the write fails.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn write_size_prefixed_string<P, W>(writer: &mut W, value: &str) -> io::Result<()>
 where
@@ -181,7 +186,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the element count does not fit the prefix type or any write fails.
+/// Returns an [`io::Error`] if the element count does not fit the prefix type
+/// or any write fails.
 #[instrument(level = "debug", skip_all, err, fields(entry_count = elements.len()))]
 pub fn write_size_prefixed_seq<P, W, T, F>(
     writer: &mut W,

--- a/crates/foundation/streamext/src/io.rs
+++ b/crates/foundation/streamext/src/io.rs
@@ -5,6 +5,10 @@ use tracing::instrument;
 use crate::prelude::*;
 
 /// Reads a byte buffer prefixed by a little-endian length.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the prefix or the subsequent bytes cannot be read, or if the prefix length does not match `expect_fixed_size`.
 #[instrument(
     level = "debug",
     skip_all,
@@ -34,6 +38,10 @@ where
 }
 
 /// Reads a UTF-8 string prefixed by a little-endian length.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the bytes cannot be read or are not valid UTF-8.
 #[instrument(
     level = "debug",
     skip_all,
@@ -53,6 +61,10 @@ where
 }
 
 /// Reads exactly `size` bytes.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_bytes<R: Read>(reader: &mut R, size: usize) -> io::Result<Vec<u8>> {
     let mut bytes = vec![0_u8; size];
@@ -61,6 +73,10 @@ pub fn read_bytes<R: Read>(reader: &mut R, size: usize) -> io::Result<Vec<u8>> {
 }
 
 /// Reads exactly `size` bytes and decodes them as UTF-8.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the reader cannot supply exactly `size` bytes or the bytes are not valid UTF-8.
 #[instrument(level = "debug", skip_all, err, fields(size))]
 pub fn read_string<R: Read>(reader: &mut R, size: usize) -> io::Result<String> {
     let bytes = read_bytes(reader, size)?;
@@ -68,6 +84,10 @@ pub fn read_string<R: Read>(reader: &mut R, size: usize) -> io::Result<String> {
 }
 
 /// Reads and validates a fixed byte sequence.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the bytes cannot be read or do not match `value`.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn read_fixed_value<R: Read>(reader: &mut R, value: &[u8]) -> io::Result<()> {
     let data = read_bytes(reader, value.len())?;
@@ -85,6 +105,10 @@ pub fn read_fixed_value<R: Read>(reader: &mut R, value: &[u8]) -> io::Result<()>
 }
 
 /// Reads exactly `count` elements using `item_reader`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if `item_reader` fails for any element.
 #[instrument(level = "debug", skip_all, err, fields(count))]
 pub fn read_fixed_count_seq<R, T, F>(
     reader: &mut R,
@@ -103,6 +127,10 @@ where
 }
 
 /// Reads a sequence prefixed by an element count.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the prefix or any element cannot be read.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_size_prefixed_seq<P, R, T, F>(reader: &mut R, item_reader: F) -> io::Result<Vec<T>>
 where
@@ -115,6 +143,10 @@ where
 }
 
 /// Writes a byte buffer prefixed by its length.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the length does not fit the prefix type or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn write_size_prefixed_bytes<P, W>(writer: &mut W, value: &[u8]) -> io::Result<()>
 where
@@ -132,6 +164,10 @@ where
 }
 
 /// Writes a UTF-8 string prefixed by its byte length.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the byte length does not fit the prefix type or the write fails.
 #[instrument(level = "debug", skip_all, err, fields(size = value.len()))]
 pub fn write_size_prefixed_string<P, W>(writer: &mut W, value: &str) -> io::Result<()>
 where
@@ -142,6 +178,10 @@ where
 }
 
 /// Writes a sequence prefixed by its element count.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the element count does not fit the prefix type or any write fails.
 #[instrument(level = "debug", skip_all, err, fields(entry_count = elements.len()))]
 pub fn write_size_prefixed_seq<P, W, T, F>(
     writer: &mut W,
@@ -167,6 +207,10 @@ where
 }
 
 /// Reads an array of exactly `N` elements.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if `item_reader` fails for any element.
 #[instrument(level = "debug", skip_all, err, fields(count = N))]
 pub fn read_array<const N: usize, R, T, F>(reader: &mut R, mut item_reader: F) -> io::Result<[T; N]>
 where

--- a/crates/foundation/streamext/src/size_prefix.rs
+++ b/crates/foundation/streamext/src/size_prefix.rs
@@ -3,8 +3,16 @@ use std::io::{self, Read, Write};
 /// A length prefix type used by the size-prefixed helpers in this crate.
 pub trait SizePrefix: Copy + TryFrom<usize> {
     /// Reads a prefix value from `reader` using little-endian encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] if the reader cannot supply enough bytes.
     fn read_from<R: Read>(reader: &mut R) -> io::Result<Self>;
     /// Writes a prefix value to `writer` using little-endian encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] if the write fails.
     fn write_to<W: Write>(self, writer: &mut W) -> io::Result<()>;
     /// Converts the prefix value into a `usize`.
     fn as_usize(self) -> usize;

--- a/crates/language/nwscript/src/codegen.rs
+++ b/crates/language/nwscript/src/codegen.rs
@@ -160,7 +160,8 @@ impl From<CodegenError> for CompileError {
 ///
 /// # Errors
 ///
-/// Returns [`CompileError`] if semantic analysis, HIR lowering, or NCS emission fails.
+/// Returns [`CompileError`] if semantic analysis, HIR lowering, or NCS emission
+/// fails.
 pub fn compile_script(
     script: &Script,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/codegen.rs
+++ b/crates/language/nwscript/src/codegen.rs
@@ -157,6 +157,10 @@ impl From<CodegenError> for CompileError {
 
 /// Compiles one parsed script through semantic analysis, HIR lowering, and `O0`
 /// NCS emission.
+///
+/// # Errors
+///
+/// Returns [`CompileError`] if semantic analysis, HIR lowering, or NCS emission fails.
 pub fn compile_script(
     script: &Script,
     langspec: Option<&LangSpec>,
@@ -166,6 +170,10 @@ pub fn compile_script(
 }
 
 /// Compiles one parsed script and emits `NDB` when a source map is available.
+///
+/// # Errors
+///
+/// Returns [`CompileError`] if compilation fails.
 pub fn compile_script_with_source_map(
     script: &Script,
     source_map: &SourceMap,
@@ -177,6 +185,10 @@ pub fn compile_script_with_source_map(
 }
 
 /// Parses and compiles one already-loaded source bundle with `NDB` output.
+///
+/// # Errors
+///
+/// Returns [`CompileError`] if parsing or compilation fails.
 pub fn compile_source_bundle(
     bundle: &SourceBundle,
     langspec: Option<&LangSpec>,
@@ -232,6 +244,10 @@ fn compile_script_with_debug(
 }
 
 /// Compiles one lowered HIR module to `NCS`.
+///
+/// # Errors
+///
+/// Returns [`CodegenError`] if code generation fails.
 pub fn compile_hir_to_ncs(
     hir: &HirModule,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/hir.rs
+++ b/crates/language/nwscript/src/hir.rs
@@ -367,6 +367,10 @@ impl fmt::Display for HirLowerError {
 impl Error for HirLowerError {}
 
 /// Lowers one semantically-valid script into typed HIR.
+///
+/// # Errors
+///
+/// Returns [`HirLowerError`] if the script cannot be lowered.
 pub fn lower_to_hir(
     script: &Script,
     semantic: &SemanticModel,

--- a/crates/language/nwscript/src/ir.rs
+++ b/crates/language/nwscript/src/ir.rs
@@ -233,6 +233,10 @@ impl fmt::Display for IrLowerError {
 impl Error for IrLowerError {}
 
 /// Lowers HIR into the compiler IR used by later codegen work.
+///
+/// # Errors
+///
+/// Returns [`IrLowerError`] if the HIR cannot be lowered.
 pub fn lower_hir_to_ir(
     hir: &HirModule,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/langspec.rs
+++ b/crates/language/nwscript/src/langspec.rs
@@ -174,11 +174,19 @@ pub fn load_langspec<R: ScriptResolver + ?Sized>(
 }
 
 /// Parses builtin declarations from one already-loaded source file.
+///
+/// # Errors
+///
+/// Returns [`LangSpecError`] if parsing fails.
 pub fn parse_langspec(source_name: &str, input: &str) -> Result<LangSpec, LangSpecError> {
     parse_langspec_bytes(source_name, input.as_bytes())
 }
 
 /// Parses builtin declarations from one already-loaded byte buffer.
+///
+/// # Errors
+///
+/// Returns [`LangSpecError`] if parsing fails.
 pub fn parse_langspec_bytes(source_name: &str, input: &[u8]) -> Result<LangSpec, LangSpecError> {
     let mut source_map = SourceMap::new();
     let root_id = source_map.add_file(source_name, input);

--- a/crates/language/nwscript/src/langspec.rs
+++ b/crates/language/nwscript/src/langspec.rs
@@ -194,6 +194,10 @@ pub fn parse_langspec_bytes(source_name: &str, input: &[u8]) -> Result<LangSpec,
 }
 
 /// Parses builtin declarations from `root_id` in `source_map`.
+///
+/// # Errors
+///
+/// Returns [`LangSpecError`] if parsing fails.
 pub fn parse_langspec_from_source_map(
     source_map: &SourceMap,
     root_id: crate::SourceId,

--- a/crates/language/nwscript/src/langspec.rs
+++ b/crates/language/nwscript/src/langspec.rs
@@ -160,6 +160,10 @@ impl From<LexerError> for LangSpecError {
 
 /// Loads `nwscript.nss` through a source resolver and parses the builtin
 /// declarations.
+///
+/// # Errors
+///
+/// Returns [`LangSpecError`] if the source cannot be loaded or parsed.
 pub fn load_langspec<R: ScriptResolver + ?Sized>(
     resolver: &R,
     script_name: &str,

--- a/crates/language/nwscript/src/lexer.rs
+++ b/crates/language/nwscript/src/lexer.rs
@@ -60,6 +60,10 @@ impl<'a> Lexer<'a> {
     }
 
     /// Lexes the entire input into a token vector ending with `Eof`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LexerError`] if an unrecognized token is encountered.
     pub fn lex_all(&mut self) -> Result<Vec<Token>, LexerError> {
         let mut tokens = Vec::new();
         loop {
@@ -663,16 +667,28 @@ impl<'a> Lexer<'a> {
 }
 
 /// Lexes the contents of one source file.
+///
+/// # Errors
+///
+/// Returns [`LexerError`] if an unrecognized token is encountered.
 pub fn lex_source(source: &SourceFile) -> Result<Vec<Token>, LexerError> {
     Lexer::new(source.id, source.bytes()).lex_all()
 }
 
 /// Lexes a byte buffer associated with `source_id`.
+///
+/// # Errors
+///
+/// Returns [`LexerError`] if an unrecognized token is encountered.
 pub fn lex_bytes(source_id: SourceId, input: &[u8]) -> Result<Vec<Token>, LexerError> {
     Lexer::new(source_id, input).lex_all()
 }
 
 /// Lexes a string slice associated with `source_id`.
+///
+/// # Errors
+///
+/// Returns [`LexerError`] if an unrecognized token is encountered.
 pub fn lex_text(source_id: SourceId, input: &str) -> Result<Vec<Token>, LexerError> {
     lex_bytes(source_id, input.as_bytes())
 }

--- a/crates/language/nwscript/src/ncs.rs
+++ b/crates/language/nwscript/src/ncs.rs
@@ -47,7 +47,8 @@ impl Error for NcsHeaderError {}
 ///
 /// # Errors
 ///
-/// Returns [`NcsHeaderError`] if the bytes are too short or the magic is invalid.
+/// Returns [`NcsHeaderError`] if the bytes are too short or the magic is
+/// invalid.
 pub fn decode_ncs_header(bytes: &[u8]) -> Result<NcsHeader, NcsHeaderError> {
     if bytes.len() < NCS_BINARY_HEADER_SIZE {
         return Err(NcsHeaderError::TooShort(bytes.len()));
@@ -623,7 +624,8 @@ fn instruction_extra_size(opcode: NcsOpcode, auxcode: NcsAuxCode, bytes: &[u8]) 
 ///
 /// # Errors
 ///
-/// Returns [`NcsReadError`] if the header is invalid or an instruction is malformed.
+/// Returns [`NcsReadError`] if the header is invalid or an instruction is
+/// malformed.
 pub fn decode_ncs_instructions(bytes: &[u8]) -> Result<Vec<NcsInstruction>, NcsReadError> {
     let header = decode_ncs_header(bytes)?;
     let mut offset = NCS_BINARY_HEADER_SIZE;

--- a/crates/language/nwscript/src/ncs.rs
+++ b/crates/language/nwscript/src/ncs.rs
@@ -44,6 +44,10 @@ impl fmt::Display for NcsHeaderError {
 impl Error for NcsHeaderError {}
 
 /// Decodes the fixed binary header of an `NCS V1.0` file.
+///
+/// # Errors
+///
+/// Returns [`NcsHeaderError`] if the bytes are too short or the magic is invalid.
 pub fn decode_ncs_header(bytes: &[u8]) -> Result<NcsHeader, NcsHeaderError> {
     if bytes.len() < NCS_BINARY_HEADER_SIZE {
         return Err(NcsHeaderError::TooShort(bytes.len()));
@@ -616,6 +620,10 @@ fn instruction_extra_size(opcode: NcsOpcode, auxcode: NcsAuxCode, bytes: &[u8]) 
 }
 
 /// Decodes a full `NCS V1.0` bytecode stream into individual instructions.
+///
+/// # Errors
+///
+/// Returns [`NcsReadError`] if the header is invalid or an instruction is malformed.
 pub fn decode_ncs_instructions(bytes: &[u8]) -> Result<Vec<NcsInstruction>, NcsReadError> {
     let header = decode_ncs_header(bytes)?;
     let mut offset = NCS_BINARY_HEADER_SIZE;

--- a/crates/language/nwscript/src/ndb.rs
+++ b/crates/language/nwscript/src/ndb.rs
@@ -194,6 +194,10 @@ impl From<ExpectationError> for NdbError {
 }
 
 /// Parses `NDB V1.0` from a buffered reader.
+///
+/// # Errors
+///
+/// Returns [`NdbError`] if the header is invalid or a record is malformed.
 pub fn read_ndb<R: BufRead>(reader: &mut R) -> Result<Ndb, NdbError> {
     let mut header = String::new();
     reader.read_line(&mut header)?;
@@ -382,12 +386,20 @@ pub fn read_ndb<R: BufRead>(reader: &mut R) -> Result<Ndb, NdbError> {
 }
 
 /// Parses `NDB V1.0` from a string slice.
+///
+/// # Errors
+///
+/// Returns [`NdbError`] if the header is invalid or a record is malformed.
 pub fn parse_ndb_str(input: &str) -> Result<Ndb, NdbError> {
     let mut reader = io::Cursor::new(input.as_bytes());
     read_ndb(&mut reader)
 }
 
 /// Writes an `NDB V1.0` file in upstream-compatible textual form.
+///
+/// # Errors
+///
+/// Returns [`NdbError`] if the write fails.
 pub fn write_ndb<W: Write>(writer: &mut W, ndb: &Ndb) -> Result<(), NdbError> {
     writeln!(writer, "NDB V1.0")?;
     writeln!(

--- a/crates/language/nwscript/src/nwasm.rs
+++ b/crates/language/nwscript/src/nwasm.rs
@@ -247,6 +247,10 @@ impl NcsInstruction {
 
     /// Renders the decoded operand payload using upstream `nwasm` formatting
     /// rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NcsAsmError`] if formatting the operand fails.
     pub fn extra_string(&self, max_string_length: usize) -> Result<String, NcsAsmError> {
         extra_string_for_instruction(self, 0, None, &BTreeMap::new(), max_string_length)
     }
@@ -429,6 +433,10 @@ pub fn assemble_ncs_text(
 
 /// Parses assembleable NCS asm text and encodes it into bytecode without the
 /// fixed NCS file header.
+///
+/// # Errors
+///
+/// Returns [`NcsAsmError`] if parsing or encoding fails.
 pub fn assemble_ncs_bytes(text: &str, langspec: Option<&LangSpec>) -> Result<Vec<u8>, NcsAsmError> {
     Ok(crate::encode_ncs_instructions(&assemble_ncs_text(
         text, langspec,

--- a/crates/language/nwscript/src/nwasm.rs
+++ b/crates/language/nwscript/src/nwasm.rs
@@ -257,6 +257,10 @@ impl NcsInstruction {
 }
 
 /// Decodes a full `NCS` stream into instruction-shaped disassembly lines.
+///
+/// # Errors
+///
+/// Returns [`NcsAsmError`] if the stream cannot be decoded.
 pub fn disassemble_ncs(
     bytes: &[u8],
     langspec: Option<&LangSpec>,
@@ -308,6 +312,10 @@ fn decode_asm_lines(
 }
 
 /// Renders a full `NCS` stream into stable human-readable disassembly text.
+///
+/// # Errors
+///
+/// Returns [`NcsAsmError`] if decoding or rendering fails.
 pub fn render_ncs_disassembly(
     bytes: &[u8],
     langspec: Option<&LangSpec>,
@@ -321,6 +329,10 @@ pub fn render_ncs_disassembly(
 }
 
 /// Renders a full `NCS` stream into NDB-aware disassembly text.
+///
+/// # Errors
+///
+/// Returns [`NcsAsmError`] if decoding or rendering fails.
 pub fn render_ncs_disassembly_with_ndb(
     bytes: &[u8],
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/nwasm.rs
+++ b/crates/language/nwscript/src/nwasm.rs
@@ -338,6 +338,10 @@ pub fn render_ncs_disassembly_with_ndb(
 }
 
 /// Parses assembleable NCS asm text into decoded instructions.
+///
+/// # Errors
+///
+/// Returns [`NcsAsmError`] if parsing fails.
 pub fn assemble_ncs_text(
     text: &str,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/parser.rs
+++ b/crates/language/nwscript/src/parser.rs
@@ -131,6 +131,10 @@ pub fn parse_source(
 }
 
 /// Lexes and parses a byte buffer associated with `source_id`.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] if lexing or parsing fails.
 pub fn parse_bytes(
     source_id: SourceId,
     input: &[u8],
@@ -141,6 +145,10 @@ pub fn parse_bytes(
 }
 
 /// Lexes and parses a text buffer associated with `source_id`.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] if lexing or parsing fails.
 pub fn parse_text(
     source_id: SourceId,
     input: &str,
@@ -164,6 +172,10 @@ pub fn parse_source_bundle(
 }
 
 /// Resolves, preprocesses, and parses one named root script.
+///
+/// # Errors
+///
+/// Returns [`ResolvedParseError`] if resolution, preprocessing, or parsing fails.
 pub fn parse_resolved_script<R: crate::ScriptResolver + ?Sized>(
     resolver: &R,
     root_name: &str,

--- a/crates/language/nwscript/src/parser.rs
+++ b/crates/language/nwscript/src/parser.rs
@@ -175,7 +175,8 @@ pub fn parse_source_bundle(
 ///
 /// # Errors
 ///
-/// Returns [`ResolvedParseError`] if resolution, preprocessing, or parsing fails.
+/// Returns [`ResolvedParseError`] if resolution, preprocessing, or parsing
+/// fails.
 pub fn parse_resolved_script<R: crate::ScriptResolver + ?Sized>(
     resolver: &R,
     root_name: &str,

--- a/crates/language/nwscript/src/parser.rs
+++ b/crates/language/nwscript/src/parser.rs
@@ -106,6 +106,10 @@ impl From<ParserError> for ResolvedParseError {
 }
 
 /// Parses one already-tokenized `NWScript` translation unit.
+///
+/// # Errors
+///
+/// Returns [`ParserError`] if the token stream is syntactically invalid.
 pub fn parse_tokens(
     tokens: Vec<Token>,
     langspec: Option<&LangSpec>,
@@ -114,6 +118,10 @@ pub fn parse_tokens(
 }
 
 /// Lexes and parses one source file.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] if lexing or parsing fails.
 pub fn parse_source(
     source: &SourceFile,
     langspec: Option<&LangSpec>,
@@ -143,6 +151,10 @@ pub fn parse_text(
 
 /// Parses one already-loaded source bundle after include traversal and macro
 /// expansion.
+///
+/// # Errors
+///
+/// Returns [`ResolvedParseError`] if preprocessing or parsing fails.
 pub fn parse_source_bundle(
     bundle: &crate::SourceBundle,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/preprocess.rs
+++ b/crates/language/nwscript/src/preprocess.rs
@@ -104,6 +104,10 @@ pub fn load_source_bundle<R: ScriptResolver + ?Sized>(
 }
 
 /// Preprocesses one already-loaded source bundle into a token stream.
+///
+/// # Errors
+///
+/// Returns [`PreprocessError`] if macro expansion or include resolution fails.
 pub fn preprocess_source_bundle(
     bundle: &SourceBundle,
 ) -> Result<PreprocessedSource, PreprocessError> {

--- a/crates/language/nwscript/src/preprocess.rs
+++ b/crates/language/nwscript/src/preprocess.rs
@@ -88,6 +88,10 @@ impl From<LexerError> for PreprocessError {
 }
 
 /// Loads a root script and recursively discovers its `#include` dependencies.
+///
+/// # Errors
+///
+/// Returns [`PreprocessError`] if any script cannot be resolved or loaded.
 pub fn load_source_bundle<R: ScriptResolver + ?Sized>(
     resolver: &R,
     root_name: &str,

--- a/crates/language/nwscript/src/sema.rs
+++ b/crates/language/nwscript/src/sema.rs
@@ -144,6 +144,10 @@ pub struct SemanticModel {
 }
 
 /// Performs semantic analysis on one parsed script.
+///
+/// # Errors
+///
+/// Returns [`SemanticError`] if the script contains semantic violations.
 pub fn analyze_script(
     script: &Script,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/sema.rs
+++ b/crates/language/nwscript/src/sema.rs
@@ -156,6 +156,10 @@ pub fn analyze_script(
 }
 
 /// Performs semantic analysis on one parsed script with explicit options.
+///
+/// # Errors
+///
+/// Returns [`SemanticError`] if the script contains semantic violations.
 pub fn analyze_script_with_options(
     script: &Script,
     langspec: Option<&LangSpec>,

--- a/crates/language/nwscript/src/source.rs
+++ b/crates/language/nwscript/src/source.rs
@@ -363,7 +363,8 @@ pub trait ScriptResolver {
     ///
     /// # Errors
     ///
-    /// Returns [`SourceError`] if the underlying resource lookup or UTF-8 decoding fails.
+    /// Returns [`SourceError`] if the underlying resource lookup or UTF-8
+    /// decoding fails.
     fn resolve_script(
         &self,
         script_name: &str,

--- a/crates/language/nwscript/src/source.rs
+++ b/crates/language/nwscript/src/source.rs
@@ -348,6 +348,10 @@ impl SourceMap {
 pub trait ScriptResolver {
     /// Returns the source bytes for `script_name`, or `None` when it does not
     /// exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SourceError`] if the underlying resource lookup fails.
     fn resolve_script_bytes(
         &self,
         script_name: &str,
@@ -356,6 +360,10 @@ pub trait ScriptResolver {
 
     /// Returns the source contents for `script_name`, or `None` when it does
     /// not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SourceError`] if the underlying resource lookup or UTF-8 decoding fails.
     fn resolve_script(
         &self,
         script_name: &str,

--- a/crates/meta/masterlist/src/lib.rs
+++ b/crates/meta/masterlist/src/lib.rs
@@ -135,7 +135,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be
+/// deserialized.
 #[instrument(level = "info", err)]
 pub async fn get_my_servers() -> Result<Me, reqwest::Error> {
     info!("fetching current caller masterlist servers");
@@ -146,7 +147,8 @@ pub async fn get_my_servers() -> Result<Me, reqwest::Error> {
 ///
 /// # Errors
 ///
-/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be
+/// deserialized.
 #[instrument(level = "info", err)]
 pub async fn get_servers() -> Result<Vec<Server>, reqwest::Error> {
     info!("fetching full masterlist server list");
@@ -157,7 +159,8 @@ pub async fn get_servers() -> Result<Vec<Server>, reqwest::Error> {
 ///
 /// # Errors
 ///
-/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be
+/// deserialized.
 #[instrument(level = "info", skip_all, err, fields(public_key = %public_key))]
 pub async fn get_servers_by_public_key(public_key: String) -> Result<Vec<Server>, reqwest::Error> {
     info!("fetching masterlist servers by public key");
@@ -168,7 +171,8 @@ pub async fn get_servers_by_public_key(public_key: String) -> Result<Vec<Server>
 ///
 /// # Errors
 ///
-/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be
+/// deserialized.
 #[instrument(level = "info", skip_all, err, fields(ip = %ip, port))]
 pub async fn get_servers_by_ip_and_port(
     ip: String,

--- a/crates/meta/masterlist/src/lib.rs
+++ b/crates/meta/masterlist/src/lib.rs
@@ -132,6 +132,10 @@ where
 }
 
 /// Fetches the `/me` response for the current caller.
+///
+/// # Errors
+///
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
 #[instrument(level = "info", err)]
 pub async fn get_my_servers() -> Result<Me, reqwest::Error> {
     info!("fetching current caller masterlist servers");
@@ -139,6 +143,10 @@ pub async fn get_my_servers() -> Result<Me, reqwest::Error> {
 }
 
 /// Fetches the full advertised server list.
+///
+/// # Errors
+///
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
 #[instrument(level = "info", err)]
 pub async fn get_servers() -> Result<Vec<Server>, reqwest::Error> {
     info!("fetching full masterlist server list");
@@ -146,6 +154,10 @@ pub async fn get_servers() -> Result<Vec<Server>, reqwest::Error> {
 }
 
 /// Fetches all servers advertising the given public key.
+///
+/// # Errors
+///
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
 #[instrument(level = "info", skip_all, err, fields(public_key = %public_key))]
 pub async fn get_servers_by_public_key(public_key: String) -> Result<Vec<Server>, reqwest::Error> {
     info!("fetching masterlist servers by public key");
@@ -153,6 +165,10 @@ pub async fn get_servers_by_public_key(public_key: String) -> Result<Vec<Server>
 }
 
 /// Fetches all servers matching the given IP address and port.
+///
+/// # Errors
+///
+/// Returns [`reqwest::Error`] if the request fails or the response cannot be deserialized.
 #[instrument(level = "info", skip_all, err, fields(ip = %ip, port))]
 pub async fn get_servers_by_ip_and_port(
     ip: String,

--- a/crates/meta/prelude/README.md
+++ b/crates/meta/prelude/README.md
@@ -29,7 +29,7 @@ If you only care about one problem area:
   [`nwsync`]
 - install-backed resource loading: start with [`restype`], [`resref`],
   [`resman`], and [`install`]
-- NWScript compilation: jump to [`nwscript`]
+- `NWScript` compilation: jump to [`nwscript`]
 - the operational entry points: see the
   [`nwnrs-cli` README](https://github.com/urothis/nwnrs/blob/main/cli/README.md)
   and the

--- a/crates/resources/install/src/builder.rs
+++ b/crates/resources/install/src/builder.rs
@@ -16,6 +16,10 @@ use crate::prelude::*;
 /// The resulting manager may include, in precedence order, additional
 /// directories, override directories, `NWSync` manifests, additional ERFs, and
 /// the selected KEY/BIF sets.
+///
+/// # Errors
+///
+/// Returns [`InstallError`] if any resource container cannot be opened.
 #[instrument(
     level = "info",
     skip(

--- a/crates/resources/install/src/discovery.rs
+++ b/crates/resources/install/src/discovery.rs
@@ -26,6 +26,10 @@ struct CandidatePath {
 ///
 /// The function returns the first existing directory when possible. If no
 /// candidate exists, it returns an error describing the accepted overrides.
+///
+/// # Errors
+///
+/// Returns [`InstallError`] if no candidate directory exists.
 #[instrument(level = "info", skip_all, err, fields(override_dir))]
 pub fn find_user_root(override_dir: &str) -> InstallResult<PathBuf> {
     find_user_root_impl(
@@ -44,6 +48,10 @@ pub fn find_user_root(override_dir: &str) -> InstallResult<PathBuf> {
 /// The returned path is required to exist as a directory. A missing
 /// `databuild.txt` is treated as a warning rather than a hard failure so local
 /// development layouts remain usable.
+///
+/// # Errors
+///
+/// Returns [`InstallError`] if no valid installation directory can be found.
 #[instrument(level = "info", skip_all, err, fields(override_dir))]
 pub fn find_nwnrs_root(override_dir: &str) -> InstallResult<PathBuf> {
     find_nwnrs_root_impl(
@@ -60,6 +68,10 @@ pub fn find_nwnrs_root(override_dir: &str) -> InstallResult<PathBuf> {
 /// This function does not guess beyond the known alias table. Failure therefore
 /// means the requested language root is genuinely absent under the provided
 /// installation.
+///
+/// # Errors
+///
+/// Returns [`InstallError`] if no matching language directory exists under `root/lang`.
 #[instrument(level = "info", skip_all, err, fields(root = %root.as_ref().display(), language))]
 pub fn resolve_language_root(root: impl AsRef<Path>, language: &str) -> InstallResult<PathBuf> {
     let root = root.as_ref();

--- a/crates/resources/install/src/discovery.rs
+++ b/crates/resources/install/src/discovery.rs
@@ -71,7 +71,8 @@ pub fn find_nwnrs_root(override_dir: &str) -> InstallResult<PathBuf> {
 ///
 /// # Errors
 ///
-/// Returns [`InstallError`] if no matching language directory exists under `root/lang`.
+/// Returns [`InstallError`] if no matching language directory exists under
+/// `root/lang`.
 #[instrument(level = "info", skip_all, err, fields(root = %root.as_ref().display(), language))]
 pub fn resolve_language_root(root: impl AsRef<Path>, language: &str) -> InstallResult<PathBuf> {
     let root = root.as_ref();

--- a/crates/resources/resdir/src/read.rs
+++ b/crates/resources/resdir/src/read.rs
@@ -19,7 +19,8 @@ use crate::{ResDir, ResDirError, ResDirResult};
 ///
 /// # Errors
 ///
-/// Returns [`ResDirError`] if the path is not a directory or any file metadata cannot be read.
+/// Returns [`ResDirError`] if the path is not a directory or any file metadata
+/// cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_resdir(path: impl AsRef<Path>) -> ResDirResult<ResDir> {
     let root = path.as_ref();

--- a/crates/resources/resdir/src/read.rs
+++ b/crates/resources/resdir/src/read.rs
@@ -16,6 +16,10 @@ use tracing::{debug, instrument};
 use crate::{ResDir, ResDirError, ResDirResult};
 
 /// Reads a directory tree as a flat resource container.
+///
+/// # Errors
+///
+/// Returns [`ResDirError`] if the path is not a directory or any file metadata cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_resdir(path: impl AsRef<Path>) -> ResDirResult<ResDir> {
     let root = path.as_ref();

--- a/crates/resources/resfile/README.md
+++ b/crates/resources/resfile/README.md
@@ -5,7 +5,7 @@ Single-file `nwnrs-resman::ResContainer` implementation.
 ## Why This Crate Exists
 
 Tools occasionally need to inject a single file into a `ResMan` lookup chain —
-for example, a lone NWScript standard library or a standalone blueprint. Without
+for example, a lone `NWScript` standard library or a standalone blueprint. Without
 a single-file `ResContainer`, callers would need a temporary directory or a
 custom container type. This crate provides the minimal wrapper so any file can
 be surfaced through the standard resource interface.

--- a/crates/resources/resfile/src/read.rs
+++ b/crates/resources/resfile/src/read.rs
@@ -18,7 +18,8 @@ use crate::{ResFile, ResFileError, ResFileResult};
 ///
 /// # Errors
 ///
-/// Returns [`ResFileError`] if the filename cannot be resolved or the file cannot be read.
+/// Returns [`ResFileError`] if the filename cannot be resolved or the file
+/// cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_resfile(path: impl AsRef<Path>) -> ResFileResult<ResFile> {
     let path = path.as_ref();
@@ -34,7 +35,8 @@ pub fn read_resfile(path: impl AsRef<Path>) -> ResFileResult<ResFile> {
 ///
 /// # Errors
 ///
-/// Returns [`ResFileError`] if the path is not a regular file or metadata cannot be read.
+/// Returns [`ResFileError`] if the path is not a regular file or metadata
+/// cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display(), resref = %resref))]
 pub fn read_resfile_as(path: impl AsRef<Path>, resref: ResRef) -> ResFileResult<ResFile> {
     let path = path.as_ref();

--- a/crates/resources/resfile/src/read.rs
+++ b/crates/resources/resfile/src/read.rs
@@ -15,6 +15,10 @@ use tracing::{debug, instrument};
 use crate::{ResFile, ResFileError, ResFileResult};
 
 /// Reads a resource file using its filename-derived resource reference.
+///
+/// # Errors
+///
+/// Returns [`ResFileError`] if the filename cannot be resolved or the file cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn read_resfile(path: impl AsRef<Path>) -> ResFileResult<ResFile> {
     let path = path.as_ref();
@@ -27,6 +31,10 @@ pub fn read_resfile(path: impl AsRef<Path>) -> ResFileResult<ResFile> {
 }
 
 /// Reads a resource file with an explicit resource reference override.
+///
+/// # Errors
+///
+/// Returns [`ResFileError`] if the path is not a regular file or metadata cannot be read.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display(), resref = %resref))]
 pub fn read_resfile_as(path: impl AsRef<Path>, resref: ResRef) -> ResFileResult<ResFile> {
     let path = path.as_ref();

--- a/crates/resources/resman/src/manager.rs
+++ b/crates/resources/resman/src/manager.rs
@@ -64,6 +64,10 @@ impl ResMan {
     ///
     /// When [`CachePolicy::Use`] is selected, successful lookups are memoized
     /// in the manager cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if no container provides the requested resource or the demand fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %rr, cache_policy = ?cache_policy))]
     pub fn demand(&mut self, rr: &ResRef, cache_policy: CachePolicy) -> ResManResult<Res> {
         if cache_policy.uses_cache()

--- a/crates/resources/resman/src/manager.rs
+++ b/crates/resources/resman/src/manager.rs
@@ -67,7 +67,8 @@ impl ResMan {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if no container provides the requested resource or the demand fails.
+    /// Returns [`ResManError`] if no container provides the requested resource
+    /// or the demand fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %rr, cache_policy = ?cache_policy))]
     pub fn demand(&mut self, rr: &ResRef, cache_policy: CachePolicy) -> ResManResult<Res> {
         if cache_policy.uses_cache()

--- a/crates/resources/resman/src/types.rs
+++ b/crates/resources/resman/src/types.rs
@@ -348,6 +348,10 @@ impl Res {
     ///
     /// This is mainly useful for callers performing manual reads with
     /// [`with_stream`](Self::with_stream).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if the stream cannot be locked or the seek fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn seek(&self) -> ResManResult<()> {
         self.with_stream(|stream| {
@@ -360,6 +364,10 @@ impl Res {
     ///
     /// When [`CachePolicy::Use`] is selected, small decoded payloads are
     /// retained in memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if the stream cannot be read or decompression fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref, cache_policy = ?cache_policy))]
     pub fn read_all(&self, cache_policy: CachePolicy) -> ResManResult<Vec<u8>> {
         if cache_policy.uses_cache() {
@@ -390,6 +398,10 @@ impl Res {
     ///
     /// If the digest was not provided by the container, it is computed lazily
     /// and cached.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if the payload cannot be read or the state lock is poisoned.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn sha1(&self) -> ResManResult<SecureHash> {
         {
@@ -409,6 +421,10 @@ impl Res {
     ///
     /// Shared-stream resources lock the stream for the duration of the
     /// callback. Spawned resources create a fresh stream for the call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if the stream cannot be locked, spawned, or if `op` fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn with_stream<T, F>(&self, op: F) -> ResManResult<T>
     where
@@ -459,6 +475,10 @@ pub trait ResContainer: fmt::Display + Send + Sync {
     /// Returns whether the container can resolve `rr`.
     fn contains(&self, rr: &ResRef) -> bool;
     /// Returns the resource identified by `rr` or an error when it is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResManError`] if the resource is not present or cannot be loaded.
     fn demand(&self, rr: &ResRef) -> ResManResult<Res>;
     /// Returns the number of resources exposed by the container.
     fn count(&self) -> usize;

--- a/crates/resources/resman/src/types.rs
+++ b/crates/resources/resman/src/types.rs
@@ -351,7 +351,8 @@ impl Res {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if the stream cannot be locked or the seek fails.
+    /// Returns [`ResManError`] if the stream cannot be locked or the seek
+    /// fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn seek(&self) -> ResManResult<()> {
         self.with_stream(|stream| {
@@ -367,7 +368,8 @@ impl Res {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if the stream cannot be read or decompression fails.
+    /// Returns [`ResManError`] if the stream cannot be read or decompression
+    /// fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref, cache_policy = ?cache_policy))]
     pub fn read_all(&self, cache_policy: CachePolicy) -> ResManResult<Vec<u8>> {
         if cache_policy.uses_cache() {
@@ -401,7 +403,8 @@ impl Res {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if the payload cannot be read or the state lock is poisoned.
+    /// Returns [`ResManError`] if the payload cannot be read or the state lock
+    /// is poisoned.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn sha1(&self) -> ResManResult<SecureHash> {
         {
@@ -424,7 +427,8 @@ impl Res {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if the stream cannot be locked, spawned, or if `op` fails.
+    /// Returns [`ResManError`] if the stream cannot be locked, spawned, or if
+    /// `op` fails.
     #[instrument(level = "debug", skip_all, err, fields(resref = %self.inner.resref))]
     pub fn with_stream<T, F>(&self, op: F) -> ResManResult<T>
     where
@@ -478,7 +482,8 @@ pub trait ResContainer: fmt::Display + Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns [`ResManError`] if the resource is not present or cannot be loaded.
+    /// Returns [`ResManError`] if the resource is not present or cannot be
+    /// loaded.
     fn demand(&self, rr: &ResRef) -> ResManResult<Res>;
     /// Returns the number of resources exposed by the container.
     fn count(&self) -> usize;

--- a/crates/resources/resmemfile/src/read.rs
+++ b/crates/resources/resmemfile/src/read.rs
@@ -9,6 +9,10 @@ use tracing::{debug, instrument};
 use crate::{ResMemFile, ResMemFileResult};
 
 /// Wraps owned bytes as a one-entry in-memory resource container.
+///
+/// # Errors
+///
+/// Returns [`ResMemFileError`] if the resource reference is invalid.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_resmemfile(
     label: impl Into<String>,
@@ -43,6 +47,10 @@ pub fn read_resmemfile(
 }
 
 /// Wraps shared bytes as a one-entry in-memory resource container.
+///
+/// # Errors
+///
+/// Returns [`ResMemFileError`] if the resource reference is invalid.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_resmemfile_arc(
     label: impl Into<String>,

--- a/crates/resources/resnwsync/README.md
+++ b/crates/resources/resnwsync/README.md
@@ -6,7 +6,7 @@ Access to `NWSync` repositories as resource containers.
 
 `NWSync` repositories are SQLite-backed shard stores, not a format that `ResMan`
 can consume directly. Without this crate, every tool that wants to query a
-`NWSync` repository would need to open SQLite and implement shard resolution
+`NWSync` repository would need to open `SQLite` and implement shard resolution
 itself. This crate wraps that complexity and exposes individual manifests as
 standard `ResContainer` values that slot into any `ResMan` lookup chain.
 

--- a/crates/resources/resnwsync/src/io.rs
+++ b/crates/resources/resnwsync/src/io.rs
@@ -33,7 +33,8 @@ pub fn nwsync_compressed_buf_magic() -> ResNWSyncResult<u32> {
 ///
 /// # Errors
 ///
-/// Returns [`ResNWSyncError`] if the meta database is missing, a shard database is not found, or any SQL query fails.
+/// Returns [`ResNWSyncError`] if the meta database is missing, a shard database
+/// is not found, or any SQL query fails.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn open_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
     let root = path.as_ref().to_path_buf();
@@ -99,7 +100,8 @@ pub fn open_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
 ///
 /// # Errors
 ///
-/// Returns [`ResNWSyncError`] if the directory cannot be created or the database cannot be initialized.
+/// Returns [`ResNWSyncError`] if the directory cannot be created or the
+/// database cannot be initialized.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn open_or_create_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
     let root = path.as_ref();

--- a/crates/resources/resnwsync/src/io.rs
+++ b/crates/resources/resnwsync/src/io.rs
@@ -19,6 +19,10 @@ use crate::{
 };
 
 /// Returns the integer magic for `NSYC` compressed buffers.
+///
+/// # Errors
+///
+/// Returns [`ResNWSyncError`] if the magic string cannot be encoded.
 #[instrument(level = "debug", skip_all, err)]
 pub fn nwsync_compressed_buf_magic() -> ResNWSyncResult<u32> {
     make_magic(NWSYNC_COMPRESSED_BUF_MAGIC_STR)
@@ -26,6 +30,10 @@ pub fn nwsync_compressed_buf_magic() -> ResNWSyncResult<u32> {
 }
 
 /// Opens an `NWSync` repository rooted at `path`.
+///
+/// # Errors
+///
+/// Returns [`ResNWSyncError`] if the meta database is missing, a shard database is not found, or any SQL query fails.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn open_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
     let root = path.as_ref().to_path_buf();
@@ -88,6 +96,10 @@ pub fn open_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
 
 /// Opens an `NWSync` repository, creating the minimal `SQLite` layout when
 /// needed.
+///
+/// # Errors
+///
+/// Returns [`ResNWSyncError`] if the directory cannot be created or the database cannot be initialized.
 #[instrument(level = "debug", skip_all, err, fields(path = %path.as_ref().display()))]
 pub fn open_or_create_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> {
     let root = path.as_ref();

--- a/crates/resources/resnwsync/src/io.rs
+++ b/crates/resources/resnwsync/src/io.rs
@@ -124,6 +124,10 @@ pub fn open_or_create_nwsync(path: impl AsRef<Path>) -> ResNWSyncResult<NWSync> 
 }
 
 /// Exposes a single manifest row as a resource container.
+///
+/// # Errors
+///
+/// Returns [`ResNWSyncError`] if the manifest cannot be read from the database.
 #[instrument(level = "debug", skip_all, err, fields(manifest_sha1 = %manifest_sha1))]
 pub fn new_resnwsync_manifest(
     nwsync: &NWSync,

--- a/crates/resources/resnwsync/src/types.rs
+++ b/crates/resources/resnwsync/src/types.rs
@@ -266,6 +266,10 @@ impl NWSync {
     }
 
     /// Deletes payload blobs by SHA-1 and returns the number of deleted rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResNWSyncError`] if the database operation fails.
     pub fn delete_resref_data(&mut self, sha1s: &[ResRefSha1]) -> ResNWSyncResult<usize> {
         let mut grouped = HashMap::<ShardId, Vec<ResRefSha1>>::new();
         for sha1 in sha1s {

--- a/crates/resources/resnwsync/src/types.rs
+++ b/crates/resources/resnwsync/src/types.rs
@@ -134,6 +134,10 @@ impl NWSync {
     }
 
     /// Returns all manifest hashes stored in the repository.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResNWSyncError`] if the database cannot be queried.
     pub fn get_all_manifests(&self) -> ResNWSyncResult<Vec<ManifestSha1>> {
         let conn = self.meta_connection()?;
         let mut stmt = conn.prepare("select sha1 from manifests")?;
@@ -159,6 +163,10 @@ impl NWSync {
 
     /// Reads a resource payload by hash, decompressing `NSYC` buffers when
     /// needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResNWSyncError`] if the hash is not found or the data cannot be read or decompressed.
     pub fn read_resref_data(&self, sha1: ResRefSha1) -> ResNWSyncResult<Vec<u8>> {
         let Some(shard_id) = self.shardmap.get(&sha1).copied() else {
             return Err(ResNWSyncError::msg(format!("not found: {sha1}")));
@@ -200,6 +208,10 @@ impl NWSync {
 
     /// Writes a payload blob to the default shard when it is not already
     /// present.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResNWSyncError`] if the database write fails.
     pub fn put_resref_data(&mut self, sha1: ResRefSha1, data: &[u8]) -> ResNWSyncResult<bool> {
         if self.shardmap.contains_key(&sha1) {
             return Ok(false);

--- a/crates/resources/resnwsync/src/types.rs
+++ b/crates/resources/resnwsync/src/types.rs
@@ -166,7 +166,8 @@ impl NWSync {
     ///
     /// # Errors
     ///
-    /// Returns [`ResNWSyncError`] if the hash is not found or the data cannot be read or decompressed.
+    /// Returns [`ResNWSyncError`] if the hash is not found or the data cannot
+    /// be read or decompressed.
     pub fn read_resref_data(&self, sha1: ResRefSha1) -> ResNWSyncResult<Vec<u8>> {
         let Some(shard_id) = self.shardmap.get(&sha1).copied() else {
             return Err(ResNWSyncError::msg(format!("not found: {sha1}")));

--- a/crates/resources/resref/src/types.rs
+++ b/crates/resources/resref/src/types.rs
@@ -63,6 +63,10 @@ pub struct ResolvedResRef {
 
 impl ResRef {
     /// Creates a new resource reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResRefError`] if `res_ref` is not a valid resource reference name.
     pub fn new(res_ref: impl Into<String>, res_type: ResType) -> Result<Self, ResRefError> {
         let res_ref = res_ref.into();
         nwnrs_io::expect(
@@ -140,6 +144,10 @@ impl fmt::Display for ResRef {
 
 impl ResolvedResRef {
     /// Creates a new resolved resource reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResRefError`] if `res_ref` is invalid or `res_type` cannot be resolved to a file extension.
     pub fn new(res_ref: impl Into<String>, res_type: ResType) -> Result<Self, ResRefError> {
         let res_ref = res_ref.into();
         let resolved = ResRef::new(res_ref.clone(), res_type)?
@@ -165,6 +173,10 @@ impl ResolvedResRef {
     }
 
     /// Resolves a `name.ext` filename into a resource reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResRefError`] if `filename` cannot be parsed as a resolvable resource reference.
     pub fn from_filename(filename: &str) -> Result<Self, ResRefError> {
         Self::try_from_filename(filename)
             .ok_or_else(|| ResRefError::Message(format!("'{filename}' is not a resolvable resref")))

--- a/crates/resources/resref/src/types.rs
+++ b/crates/resources/resref/src/types.rs
@@ -66,7 +66,8 @@ impl ResRef {
     ///
     /// # Errors
     ///
-    /// Returns [`ResRefError`] if `res_ref` is not a valid resource reference name.
+    /// Returns [`ResRefError`] if `res_ref` is not a valid resource reference
+    /// name.
     pub fn new(res_ref: impl Into<String>, res_type: ResType) -> Result<Self, ResRefError> {
         let res_ref = res_ref.into();
         nwnrs_io::expect(
@@ -147,7 +148,8 @@ impl ResolvedResRef {
     ///
     /// # Errors
     ///
-    /// Returns [`ResRefError`] if `res_ref` is invalid or `res_type` cannot be resolved to a file extension.
+    /// Returns [`ResRefError`] if `res_ref` is invalid or `res_type` cannot be
+    /// resolved to a file extension.
     pub fn new(res_ref: impl Into<String>, res_type: ResType) -> Result<Self, ResRefError> {
         let res_ref = res_ref.into();
         let resolved = ResRef::new(res_ref.clone(), res_type)?
@@ -176,7 +178,8 @@ impl ResolvedResRef {
     ///
     /// # Errors
     ///
-    /// Returns [`ResRefError`] if `filename` cannot be parsed as a resolvable resource reference.
+    /// Returns [`ResRefError`] if `filename` cannot be parsed as a resolvable
+    /// resource reference.
     pub fn from_filename(filename: &str) -> Result<Self, ResRefError> {
         Self::try_from_filename(filename)
             .ok_or_else(|| ResRefError::Message(format!("'{filename}' is not a resolvable resref")))

--- a/crates/resources/restype/src/registry.rs
+++ b/crates/resources/restype/src/registry.rs
@@ -115,6 +115,10 @@ macro_rules! builtin_res_types {
 }
 
 /// Registers a custom resource type and extension mapping.
+///
+/// # Errors
+///
+/// Returns [`RegisterResTypeError`] if the extension is invalid or already registered.
 #[instrument(
     level = "debug",
     skip_all,

--- a/crates/resources/restype/src/registry.rs
+++ b/crates/resources/restype/src/registry.rs
@@ -118,7 +118,8 @@ macro_rules! builtin_res_types {
 ///
 /// # Errors
 ///
-/// Returns [`RegisterResTypeError`] if the extension is invalid or already registered.
+/// Returns [`RegisterResTypeError`] if the extension is invalid or already
+/// registered.
 #[instrument(
     level = "debug",
     skip_all,


### PR DESCRIPTION
## Summary

Add `# Errors` doc sections to every public function and method that returns a `Result` or `Option`, covering all crates in the workspace. Also includes two `style:` fixup commits that normalize error message formatting.

## Scope

Every crate received coverage in a single focused pass:

| Area | Functions documented |
|---|---|
| `nwnrs-io` | `seek`, `read_all`, `sha1`, `with_stream`, `demand`, `read_resdir`, `read_erf`, `read_erf_from_file`, `read_erf_shared`, `read_key_table`, `read_key_table_from_file`, `read_resfile`, `read_twoda`, `write_twoda`, `read_model`, `write_model`, `nwsync_compressed_buf_magic`, `open_nwsync`, `open_or_create_nwsync`, TXI helpers |
| `nwnrs-encoding` | encoding/decoding conversion functions |
| `nwnrs-checksums` | `parse_secure_hash` |
| `nwnrs-streamext` | `SizePrefix` trait methods |
| `nwnrs-resman` | `demand` |
| `nwnrs-resref` | `ResRef` and `ResolvedResRef` constructors |
| `nwnrs-resmemfile` | `read_resmemfile`, `read_resmemfile_arc` |
| `nwnrs-resnwsync` | `get_all_manifests`, `read_resref_data`, `put_resref_data` |
| `nwnrs-resdir` | `read_resdir` |
| `nwnrs-install` | `find_user_root`, `find_nwnrs_root` |
| `nwnrs-masterlist` | `get_my_servers`, `get_servers`, `get_servers_by_public_key`, `get_servers_by_ip_and_port` |
| `nwnrs-gff` | `read_gff_root`, `write_gff_root`, `merge_root_preserving_provenance`, `put_field`, `put_value` |
| `nwnrs-ssf` | `read_ssf`, `write_ssf` |
| `nwnrs-tlk` | `read_single_tlk`, `write_single_tlk`, `write_tlk_chain`, `SingleTlk` methods |
| `nwnrs-twoda` | `set_cell`, `set_row_label`, `replace_rows`, `set_columns`, `as_2da`, `escape_field` |
| `nwnrs-erf` | `read_erf_from_file`, `read_erf_shared` |
| `nwnrs-mtr` | `from_file`, `from_res`, `read_mtr`, `write_mtr` |
| `nwnrs-plt` | `pixel_count`, `pixel_at`, `read_from_texture_bytes`, `render_rgba8`, `from_file`, `from_res` |
| `nwnrs-tga` | `TgaTexture` methods, `read_tga` |
| `nwnrs-dds` | `DdsMipLevel` and `DdsTexture` methods |
| `nwnrs-set` | `SetFile` methods, `read_set` |
| `nwnrs-git` | `GitFile` methods, `read_git` |
| `nwnrs-nwsync` | `read_manifest`, `read_manifest_file`, `write_manifest_file`, `hash_tree_depth`, `algorithm` |
| `nwnrs-mdl` | `from_file`, `from_res`, `parse_ascii`, `parse_ascii_model`, `lower_binary_model_to_ascii`, `compile_ascii_model`, `read_ascii_model`, `write_ascii_model`, `read_model`, `write_model`, scene writing and baking functions, semantic model functions, `sample_scene_default_animation` |
| `nwnrs-nwscript` | `langspec`, `lexer`, `ncs`, `ndb`, `nwasm`, compiler and parsing modules |

## Style fixes

- Normalized error message formatting for consistency across all doc comments
- Corrected return type documentation for `write` functions in `io.rs`
- Corrected error type documentation for `write` functions in `io.rs`
- Improved formatting for `NWSync` and `NWScript` references in documentation
