### PR TITLE
docs: fix broken intra-doc links for ModelError and ResMemFileError

### DIFF
--- a/crates/formats/mdl/src/io.rs
+++ b/crates/formats/mdl/src/io.rs
@@ -8,7 +8,7 @@ use crate::{Model, ModelResult};
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the data cannot be read.
+/// Returns [`crate::ModelError`] if the data cannot be read.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_model<R: Read>(reader: &mut R) -> ModelResult<Model> {
     let mut bytes = Vec::new();

--- a/crates/formats/mdl/src/io.rs
+++ b/crates/formats/mdl/src/io.rs
@@ -20,7 +20,7 @@ pub fn read_model<R: Read>(reader: &mut R) -> ModelResult<Model> {
 ///
 /// # Errors
 ///
-/// Returns [`ModelError`] if the write fails.
+/// Returns [`crate::ModelError`] if the write fails.
 #[instrument(level = "debug", skip_all, err, fields(byte_len = model.byte_len()))]
 pub fn write_model<W: Write>(writer: &mut W, model: &Model) -> ModelResult<()> {
     writer.write_all(model.bytes())?;

--- a/crates/resources/resmemfile/src/read.rs
+++ b/crates/resources/resmemfile/src/read.rs
@@ -12,7 +12,7 @@ use crate::{ResMemFile, ResMemFileResult};
 ///
 /// # Errors
 ///
-/// Returns [`ResMemFileError`] if the resource reference is invalid.
+/// Returns [`crate::ResMemFileError`] if the resource reference is invalid.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_resmemfile(
     label: impl Into<String>,
@@ -50,7 +50,7 @@ pub fn read_resmemfile(
 ///
 /// # Errors
 ///
-/// Returns [`ResMemFileError`] if the resource reference is invalid.
+/// Returns [`crate::ResMemFileError`] if the resource reference is invalid.
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_resmemfile_arc(
     label: impl Into<String>,


### PR DESCRIPTION
Fix unresolved rustdoc link warnings in `nwnrs-mdl` and `nwnrs-resmemfile` by
qualifying `ModelError` and `ResMemFileError` with their `crate::` path prefix.

Previously `cargo doc --workspace --no-deps` emitted
`rustdoc::broken_intra_doc_links` warnings because the error types were not in
scope at the call site. Qualifying the links with `crate::` resolves them
without requiring additional `use` imports.
