### PR TITLE
docs: fix doctest compilation errors across dds, git, mtr, plt, set, tga, and txi crates

### DIFF
--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -362,7 +362,7 @@ impl DdsTexture {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_dds::DdsTexture::from_file;
+    /// let texture = nwnrs_dds::DdsTexture::from_file("texture.dds");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> DdsResult<Self> {
         let mut file = File::open(path.as_ref())?;

--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -423,7 +423,9 @@ pub fn read_dds<R: Read>(reader: &mut R) -> DdsResult<DdsTexture> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_dds::write_dds;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let dds = nwnrs_dds::DdsTexture::from_file("texture.dds").unwrap();
+/// nwnrs_dds::write_dds(&mut writer, &dds).unwrap();
 /// ```
 #[instrument(
     level = "debug",

--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -40,8 +40,8 @@ impl DdsError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_dds::DdsError::msg;
+    /// ```rust
+    /// let err = nwnrs_dds::DdsError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())

--- a/crates/formats/dds/src/lib.rs
+++ b/crates/formats/dds/src/lib.rs
@@ -404,7 +404,8 @@ impl DdsTexture {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_dds::read_dds;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let texture = nwnrs_dds::read_dds(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_dds<R: Read>(reader: &mut R) -> DdsResult<DdsTexture> {

--- a/crates/formats/git/src/lib.rs
+++ b/crates/formats/git/src/lib.rs
@@ -41,8 +41,8 @@ impl GitError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_git::GitError::msg;
+    /// ```rust
+    /// let err = nwnrs_git::GitError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -130,7 +130,7 @@ impl GitFile {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_git::GitFile::from_file;
+    /// let git = nwnrs_git::GitFile::from_file("area.git");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> GitResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -488,7 +488,8 @@ pub struct GitPlaceable {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_git::read_git;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let git = nwnrs_git::read_git(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_git<R: Read + Seek>(reader: &mut R) -> GitResult<GitFile> {
@@ -632,7 +633,9 @@ pub fn build_git_root(git: &GitFile) -> GitResult<GffRoot> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_git::write_git;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let git = nwnrs_git::GitFile::from_file("area.git").unwrap();
+/// nwnrs_git::write_git(&mut writer, &git).unwrap();
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn write_git<W: Write + Seek>(writer: &mut W, git: &GitFile) -> GitResult<()> {

--- a/crates/formats/mtr/src/lib.rs
+++ b/crates/formats/mtr/src/lib.rs
@@ -38,8 +38,8 @@ impl MtrError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_mtr::MtrError::msg;
+    /// ```rust
+    /// let err = nwnrs_mtr::MtrError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -132,7 +132,7 @@ impl MtrMaterial {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_mtr::MtrMaterial::from_file;
+    /// let material = nwnrs_mtr::MtrMaterial::from_file("material.mtr");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> MtrResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -175,7 +175,8 @@ impl MtrMaterial {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_mtr::read_mtr;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let material = nwnrs_mtr::read_mtr(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_mtr<R: Read>(reader: &mut R) -> MtrResult<MtrMaterial> {
@@ -271,7 +272,9 @@ pub fn parse_mtr(text: &str) -> MtrResult<MtrMaterial> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_mtr::write_mtr;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let material = nwnrs_mtr::MtrMaterial::from_file("material.mtr").unwrap();
+/// nwnrs_mtr::write_mtr(&mut writer, &material).unwrap();
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn write_mtr<W: Write>(writer: &mut W, material: &MtrMaterial) -> MtrResult<()> {

--- a/crates/formats/plt/src/lib.rs
+++ b/crates/formats/plt/src/lib.rs
@@ -41,8 +41,8 @@ impl PltError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_plt::PltError::msg;
+    /// ```rust
+    /// let err = nwnrs_plt::PltError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -397,7 +397,7 @@ impl PltTexture {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_plt::PltTexture::from_file;
+    /// let texture = nwnrs_plt::PltTexture::from_file("texture.plt");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> PltResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -439,7 +439,8 @@ impl PltTexture {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_plt::read_plt;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let texture = nwnrs_plt::read_plt(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_plt<R: Read>(reader: &mut R) -> PltResult<PltTexture> {
@@ -457,7 +458,9 @@ pub fn read_plt<R: Read>(reader: &mut R) -> PltResult<PltTexture> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_plt::write_plt;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let texture = nwnrs_plt::PltTexture::from_file("texture.plt").unwrap();
+/// nwnrs_plt::write_plt(&mut writer, &texture).unwrap();
 /// ```
 #[instrument(
     level = "debug",

--- a/crates/formats/set/src/lib.rs
+++ b/crates/formats/set/src/lib.rs
@@ -39,8 +39,8 @@ impl SetError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_set::SetError::msg;
+    /// ```rust
+    /// let err = nwnrs_set::SetError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -117,7 +117,7 @@ impl SetFile {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_set::SetFile::from_file;
+    /// let set = nwnrs_set::SetFile::from_file("tileset.set");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> SetResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -433,7 +433,8 @@ pub struct SetPrimaryRule {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_set::read_set;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let set = nwnrs_set::read_set(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_set<R: Read>(reader: &mut R) -> SetResult<SetFile> {
@@ -575,7 +576,9 @@ pub fn build_set_text(set_file: &SetFile) -> SetResult<String> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_set::write_set;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let set = nwnrs_set::SetFile::from_file("tileset.set").unwrap();
+/// nwnrs_set::write_set(&mut writer, &set).unwrap();
 /// ```
 pub fn write_set<W: Write>(writer: &mut W, set_file: &SetFile) -> SetResult<()> {
     let text = build_set_text(set_file)?;

--- a/crates/formats/tga/src/lib.rs
+++ b/crates/formats/tga/src/lib.rs
@@ -42,8 +42,8 @@ impl TgaError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_tga::TgaError::msg;
+    /// ```rust
+    /// let err = nwnrs_tga::TgaError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -416,7 +416,7 @@ impl TgaTexture {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_tga::TgaTexture::from_file;
+    /// let texture = nwnrs_tga::TgaTexture::from_file("texture.tga");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> TgaResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -458,7 +458,8 @@ impl TgaTexture {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_tga::read_tga;
+/// let mut reader = std::io::Cursor::new(vec![]);
+/// let texture = nwnrs_tga::read_tga(&mut reader);
 /// ```
 #[instrument(level = "debug", skip_all, err)]
 pub fn read_tga<R: Read>(reader: &mut R) -> TgaResult<TgaTexture> {
@@ -476,7 +477,9 @@ pub fn read_tga<R: Read>(reader: &mut R) -> TgaResult<TgaTexture> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_tga::write_tga;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let texture = nwnrs_tga::TgaTexture::from_file("texture.tga").unwrap();
+/// nwnrs_tga::write_tga(&mut writer, &texture).unwrap();
 /// ```
 #[instrument(
     level = "debug",

--- a/crates/formats/txi/src/lib.rs
+++ b/crates/formats/txi/src/lib.rs
@@ -38,8 +38,8 @@ impl TxiError {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// let _ = nwnrs_txi::TxiError::msg;
+    /// ```rust
+    /// let err = nwnrs_txi::TxiError::msg("something went wrong");
     /// ```
     pub fn msg(message: impl Into<String>) -> Self {
         Self::Message(message.into())
@@ -143,7 +143,7 @@ impl TxiFile {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let _ = nwnrs_txi::TxiFile::from_file;
+    /// let txi = nwnrs_txi::TxiFile::from_file("texture.txi");
     /// ```
     pub fn from_file(path: impl AsRef<Path>) -> TxiResult<Self> {
         let mut file = File::open(path.as_ref())?;
@@ -411,7 +411,9 @@ pub fn build_txi_text(txi_file: &TxiFile) -> TxiResult<String> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// let _ = nwnrs_txi::write_txi;
+/// let mut writer = std::io::Cursor::new(vec![]);
+/// let txi = nwnrs_txi::TxiFile::from_file("texture.txi").unwrap();
+/// nwnrs_txi::write_txi(&mut writer, &txi).unwrap();
 /// ```
 pub fn write_txi<W: Write>(writer: &mut W, txi_file: &TxiFile) -> TxiResult<()> {
     let text = build_txi_text(txi_file)?;


### PR DESCRIPTION
## Summary

- Replaced unresolvable `let _ = crate::GenericFn;` doctest stubs that caused type inference errors (`E0283`) with concrete, compilable examples
- Functions with `impl Into<String>`, `impl AsRef<Path>`, and generic `R: Read`/`W: Write` bounds now use actual call-site examples
- `no_run` preserved on examples that require filesystem or I/O; `msg()` constructors run as live doctests
- All 7 affected crates now pass `RUSTDOCFLAGS="-D warnings" cargo test --doc --workspace` cleanly

## Test plan

- [ ] `cargo test --doc --workspace` — all doctests pass
- [ ] `RUSTDOCFLAGS="-D warnings" cargo test --doc --workspace` — no warnings or failures
