### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "argh",
  "image",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "codepage",
  "encoding_rs",

--- a/crates/nwnrs/CHANGELOG.md
+++ b/crates/nwnrs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-05-02
+
+### Other
+
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/nwnrs/Cargo.toml
+++ b/crates/nwnrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -19,9 +19,9 @@ categories = [
 [dependencies]
 argh.workspace = true
 image.workspace = true
-nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.1" }
-nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.1" }
-nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.1" }
+nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.2" }
+nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.2" }
+nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.2" }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/nwpkg/CHANGELOG.md
+++ b/crates/nwpkg/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-05-02
+
+### Other
+
+- updated the following local packages: nwnrs-types

--- a/crates/nwpkg/Cargo.toml
+++ b/crates/nwpkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,7 +13,7 @@ keywords = ["nwn", "neverwinter-nights", "package", "toml", "json"]
 categories = ["config", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = [
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = [
     "checksums",
     "compressedbuf",
     "erf",

--- a/crates/nwscript/CHANGELOG.md
+++ b/crates/nwscript/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-05-02
+
+### Other
+
+- updated the following local packages: nwnrs-types, nwnrs-types

--- a/crates/nwscript/Cargo.toml
+++ b/crates/nwscript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,11 +13,11 @@ keywords = ["nwn", "neverwinter-nights", "nwscript", "compiler", "ncs"]
 categories = ["compilers", "parser-implementations", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = ["io", "resman"] }
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = ["io", "resman"] }
 serde.workspace = true
 
 [dev-dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", features = ["install"] }
+nwnrs-types = { path = "../types", version = "0.0.2", features = ["install"] }
 
 [lints]
 workspace = true

--- a/crates/types/CHANGELOG.md
+++ b/crates/types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-05-02
+
+### Other
+
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 publish = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `nwnrs-types`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs-nwpkg`: 0.0.1 -> 0.0.2
* `nwnrs-nwscript`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `nwnrs-types`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-05-02

### Other

- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>

## `nwnrs`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-05-02

### Other

- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>

## `nwnrs-nwpkg`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-05-02

### Other

- updated the following local packages: nwnrs-types
</blockquote>

## `nwnrs-nwscript`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-05-02

### Other

- updated the following local packages: nwnrs-types, nwnrs-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).