### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -268,7 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -656,16 +656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "argh",
  "image",
@@ -876,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -886,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -894,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "codepage",
  "encoding_rs",
@@ -1288,7 +1278,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1498,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1713,20 +1703,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1959,7 +1949,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2137,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/nwnrs/CHANGELOG.md
+++ b/crates/nwnrs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-05-05
+
+### Other
+
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/nwnrs/Cargo.toml
+++ b/crates/nwnrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -19,9 +19,9 @@ categories = [
 [dependencies]
 argh.workspace = true
 image.workspace = true
-nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.1" }
-nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.1" }
-nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.1" }
+nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.2" }
+nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.2" }
+nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.2" }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/nwpkg/CHANGELOG.md
+++ b/crates/nwpkg/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-05-05
+
+### Other
+
+- updated the following local packages: nwnrs-types

--- a/crates/nwpkg/Cargo.toml
+++ b/crates/nwpkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,7 +13,7 @@ keywords = ["nwn", "neverwinter-nights", "package", "toml", "json"]
 categories = ["config", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = [
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = [
     "checksums",
     "compressedbuf",
     "erf",

--- a/crates/nwscript/CHANGELOG.md
+++ b/crates/nwscript/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-05-05
+
+### Fixed
+
+- simplify candidate path resolution in discovery module.

--- a/crates/nwscript/Cargo.toml
+++ b/crates/nwscript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,11 +13,11 @@ keywords = ["nwn", "neverwinter-nights", "nwscript", "compiler", "ncs"]
 categories = ["compilers", "parser-implementations", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = ["io", "resman"] }
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = ["io", "resman"] }
 serde.workspace = true
 
 [dev-dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", features = ["install"] }
+nwnrs-types = { path = "../types", version = "0.0.2", features = ["install"] }
 
 [lints]
 workspace = true

--- a/crates/types/CHANGELOG.md
+++ b/crates/types/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-05-05
+
+### Added
+
+- add winreg dependency and enhance Windows installation discovery logic ([#52](https://github.com/urothis/nwnrs/pull/52))
+
+### Fixed
+
+- simplify candidate path resolution in discovery module.
+
+### Other
+
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 publish = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `nwnrs-types`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs-nwscript`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs-nwpkg`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `nwnrs-types`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-05-05

### Added

- add winreg dependency and enhance Windows installation discovery logic ([#52](https://github.com/urothis/nwnrs/pull/52))

### Fixed

- simplify candidate path resolution in discovery module.

### Other

- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>

## `nwnrs-nwscript`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-05-05

### Fixed

- simplify candidate path resolution in discovery module.
</blockquote>

## `nwnrs`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-05-05

### Other

- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>

## `nwnrs-nwpkg`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-05-05

### Other

- updated the following local packages: nwnrs-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).