### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "argh",
  "image",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "nwnrs-types",
  "serde",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "base64",
  "codepage",
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/nwnrs/CHANGELOG.md
+++ b/crates/nwnrs/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-07-18
+
+### Other
+
+- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))
+- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))
+- Add comprehensive tests for MDL model parsing and conversion ([#68](https://github.com/urothis/nwnrs/pull/68))
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/nwnrs/Cargo.toml
+++ b/crates/nwnrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -19,9 +19,9 @@ categories = [
 [dependencies]
 argh.workspace = true
 image.workspace = true
-nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.1" }
-nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.1" }
-nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.1" }
+nwnrs-nwpkg = { package = "nwnrs-nwpkg", path = "../nwpkg", version = "0.0.2" }
+nwnrs-nwscript = { package = "nwnrs-nwscript", path = "../nwscript", version = "0.0.2" }
+nwnrs-types = { package = "nwnrs-types", path = "../types", version = "0.0.2" }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/nwpkg/CHANGELOG.md
+++ b/crates/nwpkg/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-07-18
+
+### Other
+
+- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))

--- a/crates/nwpkg/Cargo.toml
+++ b/crates/nwpkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwpkg"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,7 +13,7 @@ keywords = ["nwn", "neverwinter-nights", "package", "toml", "json"]
 categories = ["config", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = [
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = [
     "checksums",
     "compressedbuf",
     "erf",

--- a/crates/nwscript/CHANGELOG.md
+++ b/crates/nwscript/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-07-18
+
+### Fixed
+
+- simplify candidate path resolution in discovery module.
+
+### Other
+
+- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))

--- a/crates/nwscript/Cargo.toml
+++ b/crates/nwscript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-nwscript"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 publish = true
@@ -13,11 +13,11 @@ keywords = ["nwn", "neverwinter-nights", "nwscript", "compiler", "ncs"]
 categories = ["compilers", "parser-implementations", "game-development"]
 
 [dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", default-features = false, features = ["io", "resman"] }
+nwnrs-types = { path = "../types", version = "0.0.2", default-features = false, features = ["io", "resman"] }
 serde.workspace = true
 
 [dev-dependencies]
-nwnrs-types = { path = "../types", version = "0.0.1", features = ["install"] }
+nwnrs-types = { path = "../types", version = "0.0.2", features = ["install"] }
 
 [lints]
 workspace = true

--- a/crates/types/CHANGELOG.md
+++ b/crates/types/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-07-18
+
+### Added
+
+- add winreg dependency and enhance Windows installation discovery logic ([#52](https://github.com/urothis/nwnrs/pull/52))
+
+### Fixed
+
+- simplify candidate path resolution in discovery module.
+
+### Other
+
+- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))
+- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))
+- Add comprehensive tests for MDL model parsing and conversion ([#68](https://github.com/urothis/nwnrs/pull/68))
+- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwnrs-types"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 publish = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `nwnrs-types`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs-nwpkg`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs-nwscript`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `nwnrs`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `nwnrs-types`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-types-v0.0.1...nwnrs-types-v0.0.2) - 2026-07-18

### Added

- add winreg dependency and enhance Windows installation discovery logic ([#52](https://github.com/urothis/nwnrs/pull/52))

### Fixed

- simplify candidate path resolution in discovery module.

### Other

- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))
- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))
- Add comprehensive tests for MDL model parsing and conversion ([#68](https://github.com/urothis/nwnrs/pull/68))
- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>

## `nwnrs-nwpkg`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwpkg-v0.0.1...nwnrs-nwpkg-v0.0.2) - 2026-07-18

### Other

- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))
</blockquote>

## `nwnrs-nwscript`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-nwscript-v0.0.1...nwnrs-nwscript-v0.0.2) - 2026-07-18

### Fixed

- simplify candidate path resolution in discovery module.

### Other

- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))
</blockquote>

## `nwnrs`

<blockquote>

## [0.0.2](https://github.com/urothis/nwnrs/compare/nwnrs-v0.0.1...nwnrs-v0.0.2) - 2026-07-18

### Other

- Add docker and module folders ([#72](https://github.com/urothis/nwnrs/pull/72))
- Refactor NWScript ([#71](https://github.com/urothis/nwnrs/pull/71))
- Add comprehensive tests for MDL model parsing and conversion ([#68](https://github.com/urothis/nwnrs/pull/68))
- update README.md content and enhance library documentation ([#43](https://github.com/urothis/nwnrs/pull/43))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).